### PR TITLE
Support headless with `policy_mode` and `render_mode="rgb_array"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ python scripts/record_demos_zarr.py \
   --successes_needed 1 
 ```
 
+## Headless Mode
+
+Set EGL for offscreen rendering:
+```bash
+export MUJOCO_GL=egl
+```
+
+Use `policy_mode=True` and `render_mode="rgb_array"` to construct headless environments:
+```python
+TaskConfig.get_environment(policy_mode=True, render_mode="rgb_array", ...)
+```
+`render_mode="rgb_array"` selects offscreen rendering.
+
+`policy_mode=True` disables the teleoperation wrapper and exposes the policy action interface.
+
+Teleoperation data collection (`policy_mode=False`) uses the interactive viewer, therefore does not require the headless configuration.
+
 ## Demo Format
 
 `scripts/record_demos_zarr.py` writes each successful demo as:

--- a/dexjoco/README.md
+++ b/dexjoco/README.md
@@ -13,10 +13,26 @@ pip install -e ./dexjoco
 
 ## Explore the Environments
 
-Use the top-level demo collection tool to run the maintained tasks:
+Use the top-level demo collection tool for interactive teleoperation data
+collection:
 
 ```bash
 python scripts/record_demos_zarr.py --exp_name water_plant
+```
+
+## Headless Mode
+
+Set EGL for offscreen rendering:
+
+```bash
+export MUJOCO_GL=egl
+```
+
+Use `policy_mode=True` and `render_mode="rgb_array"` to construct headless
+environments:
+
+```python
+TaskConfig.get_environment(policy_mode=True, render_mode="rgb_array", ...)
 ```
 
 ## Credits
@@ -32,7 +48,7 @@ own license terms.
 
 ## Notes
 
-For CPU-only machines that need EGL:
+For machines that require EGL for offscreen rendering:
 
 ```bash
 export MUJOCO_GL=egl

--- a/dexjoco/dexjoco/sim/envs/panda_water_plant_env.py
+++ b/dexjoco/dexjoco/sim/envs/panda_water_plant_env.py
@@ -3,7 +3,7 @@
 import random
 import time
 from pathlib import Path
-from typing import Literal
+from typing import Any, Dict, Literal, Tuple
 
 import mujoco
 import numpy as np
@@ -392,7 +392,7 @@ class PandaWaterPlantGymEnv(MujocoGymEnv):
         self._model.cam_pos[self._front_camera_id] = cam_pos
         self._model.cam_quat[self._front_camera_id] = cam_quat_wxyz
 
-    def reset(self):
+    def reset(self, seed=None, **kwargs) -> Tuple[Dict[str, np.ndarray], Dict[str, Any]]:
         """Reset the environment."""
 
         mujoco.mj_resetData(self._model, self._data)  # type: ignore

--- a/dexjoco/dexjoco/tasks/bimanual_assembly/config.py
+++ b/dexjoco/dexjoco/tasks/bimanual_assembly/config.py
@@ -3,6 +3,7 @@ from typing import Literal
 from ...sim.envs.panda_bimanual_assembly_env import PandaBimanualAssemblyGymEnv
 from ..config import TaskConfigBase
 from ..obs_adapters import DexjocoObsAdapter
+from ..policy_wrappers import DualArmPolicyWrapper
 from ..sim_teleop import (
     BimanualTeleopConfig,
     DualArmViveHandTeleopWrapper,
@@ -21,7 +22,7 @@ class TaskConfig(TaskConfigBase):
 
     def get_environment(
         self,
-        fake_env=False,
+        policy_mode=False,
         render_mode: Literal["rgb_array", "human"] = "human",
         randomize=False,
         **kwargs,
@@ -29,7 +30,9 @@ class TaskConfig(TaskConfigBase):
         env = PandaBimanualAssemblyGymEnv(
             render_mode=render_mode, randomize=randomize, hz=30, **kwargs
         )
-        if not fake_env:
+        if policy_mode:
+            env = DualArmPolicyWrapper(env)
+        else:
             env = DualArmViveHandTeleopWrapper(env, self.teleop)
         env = DexjocoObsAdapter(env, proprio_keys=self.proprio_keys)
         return env

--- a/dexjoco/dexjoco/tasks/bimanual_hanoi/config.py
+++ b/dexjoco/dexjoco/tasks/bimanual_hanoi/config.py
@@ -3,6 +3,7 @@ from typing import Literal
 from ...sim.envs.panda_bimanual_hanoi_env import PandaBimanualHanoiGymEnv
 from ..config import TaskConfigBase
 from ..obs_adapters import DexjocoObsAdapter
+from ..policy_wrappers import DualArmPolicyWrapper
 from ..sim_teleop import (
     BimanualTeleopConfig,
     DualArmViveHandTeleopWrapper,
@@ -20,7 +21,7 @@ class TaskConfig(TaskConfigBase):
 
     def get_environment(
         self,
-        fake_env=False,
+        policy_mode=False,
         render_mode: Literal["rgb_array", "human"] = "human",
         randomize=False,
         **kwargs,
@@ -28,7 +29,9 @@ class TaskConfig(TaskConfigBase):
         env = PandaBimanualHanoiGymEnv(
             render_mode=render_mode, randomize=randomize, hz=30, **kwargs
         )
-        if not fake_env:
+        if policy_mode:
+            env = DualArmPolicyWrapper(env)
+        else:
             env = DualArmViveHandTeleopWrapper(env, self.teleop)
         env = DexjocoObsAdapter(env, proprio_keys=self.proprio_keys)
         return env

--- a/dexjoco/dexjoco/tasks/bimanual_microwave_cook/config.py
+++ b/dexjoco/dexjoco/tasks/bimanual_microwave_cook/config.py
@@ -5,6 +5,7 @@ from ...sim.envs.panda_bimanual_microwave_cook_env import (
 )
 from ..config import TaskConfigBase
 from ..obs_adapters import DexjocoObsAdapter
+from ..policy_wrappers import DualArmPolicyWrapper
 from ..sim_teleop import (
     BimanualTeleopConfig,
     DualArmViveHandTeleopWrapper,
@@ -23,7 +24,7 @@ class TaskConfig(TaskConfigBase):
 
     def get_environment(
         self,
-        fake_env=False,
+        policy_mode=False,
         render_mode: Literal["rgb_array", "human"] = "human",
         randomize=False,
         **kwargs,
@@ -31,7 +32,9 @@ class TaskConfig(TaskConfigBase):
         env = PandaBimanualMicrowaveCookGymEnv(
             render_mode=render_mode, randomize=randomize, hz=30, **kwargs
         )
-        if not fake_env:
+        if policy_mode:
+            env = DualArmPolicyWrapper(env)
+        else:
             env = DualArmViveHandTeleopWrapper(env, self.teleop)
         env = DexjocoObsAdapter(env, proprio_keys=self.proprio_keys)
         return env

--- a/dexjoco/dexjoco/tasks/bimanual_photograph/config.py
+++ b/dexjoco/dexjoco/tasks/bimanual_photograph/config.py
@@ -3,6 +3,7 @@ from typing import Literal
 from ...sim.envs.panda_bimanual_photograph_env import PandaBimanualPhotographGymEnv
 from ..config import TaskConfigBase
 from ..obs_adapters import DexjocoObsAdapter
+from ..policy_wrappers import DualArmPolicyWrapper
 from ..sim_teleop import (
     BimanualTeleopConfig,
     DualArmViveHandTeleopWrapper,
@@ -21,7 +22,7 @@ class TaskConfig(TaskConfigBase):
 
     def get_environment(
         self,
-        fake_env=False,
+        policy_mode=False,
         render_mode: Literal["rgb_array", "human"] = "human",
         randomize=False,
         **kwargs,
@@ -29,7 +30,9 @@ class TaskConfig(TaskConfigBase):
         env = PandaBimanualPhotographGymEnv(
             render_mode=render_mode, randomize=randomize, hz=30, **kwargs
         )
-        if not fake_env:
+        if policy_mode:
+            env = DualArmPolicyWrapper(env)
+        else:
             env = DualArmViveHandTeleopWrapper(env, self.teleop)
         env = DexjocoObsAdapter(env, proprio_keys=self.proprio_keys)
         return env

--- a/dexjoco/dexjoco/tasks/bimanual_unlock_ipad/config.py
+++ b/dexjoco/dexjoco/tasks/bimanual_unlock_ipad/config.py
@@ -3,6 +3,7 @@ from typing import Literal
 from ...sim.envs.panda_bimanual_unlock_ipad_env import PandaBimanualUnlockIpadGymEnv
 from ..config import TaskConfigBase
 from ..obs_adapters import DexjocoObsAdapter
+from ..policy_wrappers import DualArmPolicyWrapper
 from ..sim_teleop import (
     BimanualTeleopConfig,
     DualArmViveHandTeleopWrapper,
@@ -21,7 +22,7 @@ class TaskConfig(TaskConfigBase):
 
     def get_environment(
         self,
-        fake_env=False,
+        policy_mode=False,
         render_mode: Literal["rgb_array", "human"] = "human",
         randomize=False,
         **kwargs,
@@ -29,7 +30,9 @@ class TaskConfig(TaskConfigBase):
         env = PandaBimanualUnlockIpadGymEnv(
             render_mode=render_mode, randomize=randomize, hz=30, **kwargs
         )
-        if not fake_env:
+        if policy_mode:
+            env = DualArmPolicyWrapper(env)
+        else:
             env = DualArmViveHandTeleopWrapper(env, self.teleop)
         env = DexjocoObsAdapter(env, proprio_keys=self.proprio_keys)
         return env

--- a/dexjoco/dexjoco/tasks/click_mouse/config.py
+++ b/dexjoco/dexjoco/tasks/click_mouse/config.py
@@ -3,6 +3,7 @@ from typing import Literal
 from ...sim.envs.panda_click_mouse_env import PandaClickMouseGymEnv
 from ..config import TaskConfigBase
 from ..obs_adapters import DexjocoObsAdapter
+from ..policy_wrappers import SingleArmPolicyWrapper
 from ..sim_teleop import (
     SingleArmTeleopConfig,
     SingleArmViveHandTeleopWrapper,
@@ -15,7 +16,7 @@ class TaskConfig(TaskConfigBase):
 
     def get_environment(
         self,
-        fake_env=False,
+        policy_mode=False,
         render_mode: Literal["rgb_array", "human"] = "human",
         randomize=False,
         **kwargs,
@@ -23,7 +24,9 @@ class TaskConfig(TaskConfigBase):
         env = PandaClickMouseGymEnv(
             render_mode=render_mode, randomize=randomize, hz=30, **kwargs
         )
-        if not fake_env:
+        if policy_mode:
+            env = SingleArmPolicyWrapper(env)
+        else:
             env = SingleArmViveHandTeleopWrapper(env, self.teleop)
         env = DexjocoObsAdapter(env, proprio_keys=self.proprio_keys)
         return env

--- a/dexjoco/dexjoco/tasks/config.py
+++ b/dexjoco/dexjoco/tasks/config.py
@@ -7,6 +7,11 @@ class TaskConfigBase(ABC):
 
     @abstractmethod
     def get_environment(self, policy_mode=False, render_mode="human", randomize=False, **kwargs):
+        """Create the task environment.
+
+        When ``policy_mode`` is true, implementations are expected to attach the
+        policy action wrapper instead of the teleoperation wrapper.
+        """
         pass
 
     @abstractmethod

--- a/dexjoco/dexjoco/tasks/config.py
+++ b/dexjoco/dexjoco/tasks/config.py
@@ -1,14 +1,14 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
-class TaskConfigBase:
-    """Base config for simulated teleoperation data collection."""
+class TaskConfigBase(ABC):
+    """Base config for task environments."""
 
     proprio_keys = None
 
     @abstractmethod
-    def get_environment(self, fake_env=False, render_mode="human", randomize=False, **kwargs):
-        raise NotImplementedError
+    def get_environment(self, policy_mode=False, render_mode="human", randomize=False, **kwargs):
+        pass
 
     @abstractmethod
     def process_demos(self, demo):
-        raise NotImplementedError
+        pass

--- a/dexjoco/dexjoco/tasks/fold_glasses/config.py
+++ b/dexjoco/dexjoco/tasks/fold_glasses/config.py
@@ -3,6 +3,7 @@ from typing import Literal
 from ...sim.envs.panda_fold_glasses_env import PandaFoldGlassesGymEnv
 from ..config import TaskConfigBase
 from ..obs_adapters import DexjocoObsAdapter
+from ..policy_wrappers import SingleArmPolicyWrapper
 from ..sim_teleop import (
     SingleArmTeleopConfig,
     SingleArmViveHandTeleopWrapper,
@@ -21,7 +22,7 @@ class TaskConfig(TaskConfigBase):
 
     def get_environment(
         self,
-        fake_env=False,
+        policy_mode=False,
         render_mode: Literal["rgb_array", "human"] = "human",
         randomize=False,
         **kwargs,
@@ -29,7 +30,9 @@ class TaskConfig(TaskConfigBase):
         env = PandaFoldGlassesGymEnv(
             render_mode=render_mode, randomize=randomize, hz=30, **kwargs
         )
-        if not fake_env:
+        if policy_mode:
+            env = SingleArmPolicyWrapper(env)
+        else:
             env = SingleArmViveHandTeleopWrapper(env, self.teleop)
         env = DexjocoObsAdapter(env, proprio_keys=self.proprio_keys)
         return env

--- a/dexjoco/dexjoco/tasks/hammer_nail/config.py
+++ b/dexjoco/dexjoco/tasks/hammer_nail/config.py
@@ -3,6 +3,7 @@ from typing import Literal
 from ...sim.envs.panda_hammer_nail_env import PandaHammerNailGymEnv
 from ..config import TaskConfigBase
 from ..obs_adapters import DexjocoObsAdapter
+from ..policy_wrappers import SingleArmPolicyWrapper
 from ..sim_teleop import (
     SingleArmTeleopConfig,
     SingleArmViveHandTeleopWrapper,
@@ -21,7 +22,7 @@ class TaskConfig(TaskConfigBase):
 
     def get_environment(
         self,
-        fake_env=False,
+        policy_mode=False,
         render_mode: Literal["rgb_array", "human"] = "human",
         randomize=False,
         **kwargs,
@@ -29,7 +30,9 @@ class TaskConfig(TaskConfigBase):
         env = PandaHammerNailGymEnv(
             render_mode=render_mode, randomize=randomize, hz=30, **kwargs
         )
-        if not fake_env:
+        if policy_mode:
+            env = SingleArmPolicyWrapper(env)
+        else:
             env = SingleArmViveHandTeleopWrapper(env, self.teleop)
         env = DexjocoObsAdapter(env, proprio_keys=self.proprio_keys)
         return env

--- a/dexjoco/dexjoco/tasks/pick_bucket/config.py
+++ b/dexjoco/dexjoco/tasks/pick_bucket/config.py
@@ -3,6 +3,7 @@ from typing import Literal
 from ...sim.envs.panda_pick_bucket_env import PandaPickBucketGymEnv
 from ..config import TaskConfigBase
 from ..obs_adapters import DexjocoObsAdapter
+from ..policy_wrappers import SingleArmPolicyWrapper
 from ..sim_teleop import (
     SingleArmTeleopConfig,
     SingleArmViveHandTeleopWrapper,
@@ -21,7 +22,7 @@ class TaskConfig(TaskConfigBase):
 
     def get_environment(
         self,
-        fake_env=False,
+        policy_mode=False,
         render_mode: Literal["rgb_array", "human"] = "human",
         randomize=False,
         **kwargs,
@@ -29,7 +30,9 @@ class TaskConfig(TaskConfigBase):
         env = PandaPickBucketGymEnv(
             render_mode=render_mode, randomize=randomize, hz=30, **kwargs
         )
-        if not fake_env:
+        if policy_mode:
+            env = SingleArmPolicyWrapper(env)
+        else:
             env = SingleArmViveHandTeleopWrapper(env, self.teleop)
         env = DexjocoObsAdapter(env, proprio_keys=self.proprio_keys)
         return env

--- a/dexjoco/dexjoco/tasks/pinch_tongs/config.py
+++ b/dexjoco/dexjoco/tasks/pinch_tongs/config.py
@@ -3,6 +3,7 @@ from typing import Literal
 from ...sim.envs.panda_pinch_tongs_env import PandaPinchTongsGymEnv
 from ..config import TaskConfigBase
 from ..obs_adapters import DexjocoObsAdapter
+from ..policy_wrappers import SingleArmPolicyWrapper
 from ..sim_teleop import (
     SingleArmTeleopConfig,
     SingleArmViveHandTeleopWrapper,
@@ -15,7 +16,7 @@ class TaskConfig(TaskConfigBase):
 
     def get_environment(
         self,
-        fake_env=False,
+        policy_mode=False,
         render_mode: Literal["rgb_array", "human"] = "human",
         randomize=False,
         **kwargs,
@@ -23,7 +24,9 @@ class TaskConfig(TaskConfigBase):
         env = PandaPinchTongsGymEnv(
             render_mode=render_mode, randomize=randomize, hz=30, **kwargs
         )
-        if not fake_env:
+        if policy_mode:
+            env = SingleArmPolicyWrapper(env)
+        else:
             env = SingleArmViveHandTeleopWrapper(env, self.teleop)
         env = DexjocoObsAdapter(env, proprio_keys=self.proprio_keys)
         return env

--- a/dexjoco/dexjoco/tasks/policy_wrappers.py
+++ b/dexjoco/dexjoco/tasks/policy_wrappers.py
@@ -1,0 +1,75 @@
+import gymnasium as gym
+import numpy as np
+
+
+class SingleArmPolicyWrapper(gym.ActionWrapper):
+    """Adapt single-arm policy actions to the raw single-arm task format.
+
+    Policy action layout:
+      - shape: (23,)
+      - action[0:3]: end-effector target position, xyz
+      - action[3:7]: end-effector target quaternion, wxyz
+      - action[7:23]: Allegro hand joint targets, 16 values
+
+    Raw single-arm tasks consume the same 23-dimensional array:
+      - [target_position_3, target_quaternion_4, allegro_joints_16]
+    """
+
+    def __init__(self, env):
+        super().__init__(env)
+        self.action_space = gym.spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(23,),
+            dtype=np.float32,
+        )
+
+    def action(self, action: np.ndarray) -> np.ndarray:
+        action = np.asarray(action, dtype=np.float64)
+        if action.shape != (23,):
+            raise ValueError(
+                f"Expected single-arm policy action shape (23,), got {action.shape}."
+            )
+        return action
+
+
+class DualArmPolicyWrapper(gym.ActionWrapper):
+    """Adapt bimanual policy actions to the raw bimanual task format.
+
+    Policy action layout:
+      - shape: (46,)
+      - action[0:7]: right arm target pose, [x, y, z, qw, qx, qy, qz]
+      - action[7:14]: left arm target pose, [x, y, z, qw, qx, qy, qz]
+      - action[14:30]: right Allegro hand joint targets, 16 values
+      - action[30:46]: left Allegro hand joint targets, 16 values
+
+    Raw bimanual tasks consume a dictionary:
+      - "right": shape (23,), [right_pose_7, right_hand_joints_16]
+      - "left": shape (23,), [left_pose_7, left_hand_joints_16]
+    """
+
+    def __init__(self, env):
+        super().__init__(env)
+        self.action_space = gym.spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(46,),
+            dtype=np.float32,
+        )
+
+    def action(self, action: np.ndarray) -> dict[str, np.ndarray]:
+        action = np.asarray(action, dtype=np.float64)
+        if action.shape != (46,):
+            raise ValueError(
+                f"Expected bimanual policy action shape (46,), got {action.shape}."
+            )
+
+        right_pose = action[0:7]
+        left_pose = action[7:14]
+        right_hand = action[14:30]
+        left_hand = action[30:46]
+
+        return {
+            "right": np.concatenate([right_pose, right_hand], axis=0),
+            "left": np.concatenate([left_pose, left_hand], axis=0),
+        }

--- a/dexjoco/dexjoco/tasks/water_plant/config.py
+++ b/dexjoco/dexjoco/tasks/water_plant/config.py
@@ -3,6 +3,7 @@ from typing import Literal
 from ...sim.envs.panda_water_plant_env import PandaWaterPlantGymEnv
 from ..config import TaskConfigBase
 from ..obs_adapters import DexjocoObsAdapter
+from ..policy_wrappers import SingleArmPolicyWrapper
 from ..sim_teleop import (
     SingleArmTeleopConfig,
     SingleArmViveHandTeleopWrapper,
@@ -23,7 +24,7 @@ class TaskConfig(TaskConfigBase):
 
     def get_environment(
         self,
-        fake_env: bool = False,
+        policy_mode: bool = False,
         render_mode: Literal["rgb_array", "human"] = "human",
         randomize: bool = False,
         **kwargs,
@@ -34,7 +35,9 @@ class TaskConfig(TaskConfigBase):
             hz=30,
             **kwargs,
         )
-        if not fake_env:
+        if policy_mode:
+            env = SingleArmPolicyWrapper(env)
+        else:
             env = SingleArmViveHandTeleopWrapper(env, self.teleop)
         env = DexjocoObsAdapter(env, proprio_keys=self.proprio_keys)
         return env

--- a/dexjoco/pyproject.toml
+++ b/dexjoco/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.10, <3.12"
 license = "MIT"
 authors = [
-    { name = "Hanwen Wang", email = "hanwen.wang@nlpr.ia.ac.cn" },
+    { name = "Hanwen Wang", email = "wanghanwen2025@ia.ac.cn" },
     { name = "Xiangyu Wang", email = "wangxiangyu2025@ia.ac.cn" },
     { name = "Weizhi Zhao", email = "zhaoweizhi2025@ia.ac.cn" },
 ]

--- a/scripts/record_demos_zarr.py
+++ b/scripts/record_demos_zarr.py
@@ -31,11 +31,6 @@ flags.DEFINE_string(
 )
 flags.DEFINE_integer("successes_needed", 2, "Number of successful demos to collect.")
 flags.DEFINE_bool("show_sim_cameras", True, "Show simulation cameras")
-flags.DEFINE_bool(
-    "policy_mode",
-    False,
-    "Use policy action wrappers instead of teleoperation wrappers.",
-)
 flags.DEFINE_integer(
     "max_steps",
     0,
@@ -423,7 +418,6 @@ def main(_argv):
     config = CONFIG_MAPPING[task_id]()
 
     env = config.get_environment(
-        policy_mode=FLAGS.policy_mode,
         render_mode=FLAGS.render_mode,
         randomize=FLAGS.randomize,
     )

--- a/scripts/record_demos_zarr.py
+++ b/scripts/record_demos_zarr.py
@@ -32,9 +32,9 @@ flags.DEFINE_string(
 flags.DEFINE_integer("successes_needed", 2, "Number of successful demos to collect.")
 flags.DEFINE_bool("show_sim_cameras", True, "Show simulation cameras")
 flags.DEFINE_bool(
-    "fake_env",
+    "policy_mode",
     False,
-    "Skip teleoperation wrappers when the selected task supports fake_env",
+    "Use policy action wrappers instead of teleoperation wrappers.",
 )
 flags.DEFINE_integer(
     "max_steps",
@@ -423,7 +423,7 @@ def main(_argv):
     config = CONFIG_MAPPING[task_id]()
 
     env = config.get_environment(
-        fake_env=FLAGS.fake_env,
+        policy_mode=FLAGS.policy_mode,
         render_mode=FLAGS.render_mode,
         randomize=FLAGS.randomize,
     )

--- a/scripts/test_headless_envs.py
+++ b/scripts/test_headless_envs.py
@@ -1,0 +1,42 @@
+import os
+
+os.environ.setdefault("MUJOCO_GL", "egl")
+
+import numpy as np
+
+from dexjoco.tasks.mappings import CONFIG_MAPPING
+from dexjoco.tasks.sim_teleop import BimanualTeleopConfig
+
+
+def zero_action(config):
+    if isinstance(config.teleop, BimanualTeleopConfig):
+        return np.zeros(46)
+    return np.zeros(23)
+
+
+def main():
+    for env_name, config_cls in CONFIG_MAPPING.items():
+        print(f"Testing environment: {env_name}")
+        config = config_cls()
+        env = config.get_environment(policy_mode=True, render_mode="rgb_array")
+        action = zero_action(config)
+
+        try:
+            obs, _ = env.reset()
+
+            # Optional image validation for headless evaluation.
+            # images = {k: v for k, v in obs.items() if k != "state" and isinstance(v, np.ndarray)}
+            # assert images, f"{env_name}: observation does not contain image arrays"
+
+            for _ in range(100):
+                obs, _, done, truncated, _ = env.step(action)
+                if done or truncated:
+                    obs, _ = env.reset()
+
+            print(f"{env_name}: ok")
+        finally:
+            env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_headless_envs.py
+++ b/scripts/test_headless_envs.py
@@ -1,11 +1,25 @@
 import os
+from pathlib import Path
 
 os.environ.setdefault("MUJOCO_GL", "egl")
 
+import imageio
 import numpy as np
-
 from dexjoco.tasks.mappings import CONFIG_MAPPING
 from dexjoco.tasks.sim_teleop import BimanualTeleopConfig
+
+VIDEO_ROOT = Path("./test_headless_videos")
+VIDEO_FPS = 30
+
+
+def write_observation_videos(obs, writers):
+    # DexjocoObsAdapter flattens proprioception into obs["state"] and exposes
+    # image observations as top-level keys, so only those keys are recorded.
+    for k, v in writers.items():
+        if k not in obs:
+            continue
+        frame = obs[k]
+        v.append_data(frame)
 
 
 def zero_action(config):
@@ -20,21 +34,31 @@ def main():
         config = config_cls()
         env = config.get_environment(policy_mode=True, render_mode="rgb_array")
         action = zero_action(config)
+        video_dir = VIDEO_ROOT / env_name
+        video_dir.mkdir(parents=True, exist_ok=True)
+        writers = {}
 
         try:
             obs, _ = env.reset()
-
-            # Optional image validation for headless evaluation.
-            # images = {k: v for k, v in obs.items() if k != "state" and isinstance(v, np.ndarray)}
-            # assert images, f"{env_name}: observation does not contain image arrays"
+            for k, v in obs.items():
+                if not isinstance(v, np.ndarray):
+                    continue  # not an image observation
+                if v.ndim != 3:
+                    continue  # not an image observation
+                writers[k] = imageio.get_writer(video_dir / f"{k}.mp4", fps=VIDEO_FPS)
+            write_observation_videos(obs, writers)
 
             for _ in range(100):
-                obs, _, done, truncated, _ = env.step(action)
-                if done or truncated:
+                obs, reward, terminated, truncated, info = env.step(action)
+                write_observation_videos(obs, writers)
+                if terminated or truncated:
                     obs, _ = env.reset()
+                    write_observation_videos(obs, writers)
 
             print(f"{env_name}: ok")
         finally:
+            for writer in writers.values():
+                writer.close()
             env.close()
 
 


### PR DESCRIPTION
- add `SingleArmPolicyWrapper` and `DualArmPolicyWrapper`
The policy wrappers are separate from the teleoperation wrappers. Teleop wrappers hold the current pose instead of using policy actions when teleoperation is inactive, and they need a MuJoCo viewer window to register GLFW key callbacks, which is unavailable in headless mode.
- switch task configs from `fake_env` to `policy_mode`
- update README files with headless usage instructions