### PR TITLE
Add bit-identical replay script with depth capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 /outputs/
 /checkpoints
 /datasets
+/_replay_test/
 
 teleoperation/GeoRT/checkpoint/**/*.pth
 !teleoperation/GeoRT/checkpoint/fk_model_allegro_left.pth

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 .DS_Store
+.vscode/
 
 /outputs/
 /checkpoints

--- a/dexjoco/dexjoco/data/depth_capture.py
+++ b/dexjoco/dexjoco/data/depth_capture.py
@@ -1,0 +1,150 @@
+"""Per-step depth capture for Dexjoco envs, and helpers to write depth
+videos alongside the RGB captures.
+
+The depth image is what MuJoCo calls the "linearised z-buffer": the
+distance from the camera plane to the closest surface, in metres. It is
+not Euclidean distance to the optical centre.
+
+Each env's `_compute_observation()` already calls `render()` to produce
+RGB frames; this module mirrors that call but with `render_mode=
+"depth_array"` so the camera-id ordering matches the dict ordering of
+`obs["images"]` exactly.
+
+Writing:
+- `<name>_depth.npz`: a compressed archive with a single float32 array
+  named "depth" of shape (T, H, W), in metres. Use this for training or
+  any consumer that needs the true depth.
+- `<name>_depth.mp4`: an 8-bit gray-scale H.264 preview, normalised to
+  the per-clip min/max of valid depth pixels. Lossy.
+
+Invalid pixels (depth equal to mujoco's far plane, returned when no
+geom is hit) are kept as float `inf` in the npz so consumers can mask
+them, and clipped out of the normalisation when building the mp4.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from dexjoco.data.video_writer import Mp4VideoWriter
+
+
+def _env_viewer_and_camera_ids(raw_env, image_keys):
+    """Return (viewer, [camera_id_per_image_key]) for the given env.
+
+    All envs except water_plant store the renderer at `_viewer` and the
+    ordered camera-id tuple at `camera_id`. water_plant uses `_mj_viewer`
+    and exposes the two ids individually. We probe in that order.
+    """
+    viewer = getattr(raw_env, "_viewer", None)
+    if viewer is None:
+        viewer = getattr(raw_env, "_mj_viewer", None)
+    if viewer is None:
+        return None, None
+
+    cam_ids = getattr(raw_env, "camera_id", None)
+    if cam_ids is not None:
+        cam_ids = tuple(cam_ids)
+    else:
+        wrist = getattr(raw_env, "_wrist_camera_id", None)
+        front = getattr(raw_env, "_front_camera_id", None)
+        if wrist is None or front is None or len(image_keys) != 2:
+            return viewer, None
+        # water_plant render() returns [wrist, front/random_camera].
+        cam_ids = (wrist, front)
+
+    if len(cam_ids) != len(image_keys):
+        return viewer, None
+    return viewer, cam_ids
+
+
+def _linearise_depth(zbuf, znear, zfar):
+    """Convert mujoco's nonlinear depth buffer (`mjr_readPixels` returns the
+    OpenGL z-buffer in [0, 1]) into linear depth in metres along the camera
+    ray axis. Pixels at the far plane (z == 1) become `inf`."""
+    z = np.asarray(zbuf, dtype=np.float32)
+    denom = zfar - z * (zfar - znear)
+    out = np.full_like(z, np.inf, dtype=np.float32)
+    mask = denom > 0
+    out[mask] = (znear * zfar / denom)[mask]
+    return out
+
+
+def collect_depth_frames(env, image_keys):
+    """Render a depth_array for each RGB camera key in `image_keys`.
+
+    Returns a dict mapping the same key (e.g. "wrist") to a float32
+    HxW depth image in metres, or an empty dict if depth capture is
+    not available for this env.
+    """
+    raw = env.unwrapped
+    viewer, cam_ids = _env_viewer_and_camera_ids(raw, image_keys)
+    if viewer is None or cam_ids is None:
+        return {}
+    extent = float(raw._model.stat.extent)
+    znear = float(raw._model.vis.map.znear) * extent
+    zfar = float(raw._model.vis.map.zfar) * extent
+    out = {}
+    for key, cid in zip(image_keys, cam_ids):
+        zbuf = viewer.render(render_mode="depth_array", camera_id=cid)
+        out[key] = _linearise_depth(zbuf, znear, zfar)
+    return out
+
+
+def _normalise_depth_for_preview(depth_frames):
+    """Stack and 8-bit-quantise a list of float depth frames for an mp4
+    preview. The per-clip min/max are taken over finite pixels so very
+    distant 'sky' pixels don't crush all the detail to a single bin."""
+    stack = np.stack(depth_frames, axis=0)
+    finite = stack[np.isfinite(stack)]
+    if finite.size == 0:
+        lo, hi = 0.0, 1.0
+    else:
+        lo = float(finite.min())
+        hi = float(finite.max())
+        if hi <= lo:
+            hi = lo + 1e-6
+    clipped = np.clip(stack, lo, hi)
+    norm = (clipped - lo) / (hi - lo)
+    norm[~np.isfinite(stack)] = 0.0
+    gray = (norm * 255.0).astype(np.uint8)
+    return np.repeat(gray[..., None], 3, axis=-1), lo, hi
+
+
+def write_depth_outputs(depth_frames_per_camera, videos_dir, video_fps):
+    """For each camera, write `<cam>_depth.npz` (float32 metres) and
+    `<cam>_depth.mp4` (gray H.264 preview, normalised per clip).
+
+    `depth_frames_per_camera` is a dict mapping camera key to a list of
+    per-step depth frames. The lists may be empty (camera was never
+    rendered) - in which case nothing is written for that key.
+    """
+    videos_dir = Path(videos_dir)
+    videos_dir.mkdir(parents=True, exist_ok=True)
+    saved = []
+    for cam_key, frames in depth_frames_per_camera.items():
+        if not frames:
+            continue
+        depth_stack = np.stack(frames, axis=0).astype(np.float32)
+        npz_path = videos_dir / f"{cam_key}_depth.npz"
+        np.savez_compressed(npz_path, depth=depth_stack)
+        saved.append(str(npz_path))
+
+        preview, lo, hi = _normalise_depth_for_preview(frames)
+        mp4_path = videos_dir / f"{cam_key}_depth.mp4"
+        writer = Mp4VideoWriter.create_h264(
+            fps=video_fps,
+            codec="h264",
+            input_pix_fmt="rgb24",
+            crf=21,
+            thread_type="FRAME",
+            thread_count=2,
+        )
+        writer.start(str(mp4_path))
+        for frame in preview:
+            writer.write_frame(frame)
+        writer.stop()
+        saved.append(f"{mp4_path} (depth range [{lo:.3f}, {hi:.3f}] m)")
+    return saved

--- a/dexjoco/dexjoco/sim/envs/panda_bimanual_microwave_cook_env.py
+++ b/dexjoco/dexjoco/sim/envs/panda_bimanual_microwave_cook_env.py
@@ -55,6 +55,10 @@ class PandaBimanualMicrowaveCookGymEnv(MujocoGymEnv):
             render_spec=render_spec,
         )
 
+        # Seed the RNGs used by environment randomization.
+        random.seed(seed)
+        np.random.seed(seed)
+
         self.metadata = {
             "render_modes": ["human", "rgb_array"],
             "render_fps": int(np.round(1.0 / self.control_dt)),

--- a/dexjoco/dexjoco/sim/envs/panda_water_plant_env.py
+++ b/dexjoco/dexjoco/sim/envs/panda_water_plant_env.py
@@ -611,7 +611,7 @@ class PandaWaterPlantGymEnv(MujocoGymEnv):
             "gripper_pose": allegro_qpos,
             "spray_ori_pose": self._spray_ori_pose,
             "plant_ori_pose": self._plant_ori_pose,
-            "table_delta_height": np.array([self.delta_h], dtype=np.float32),
+            "table_delta_height": np.asarray([self.delta_h], dtype=np.float64),
         }
 
         return obs

--- a/dexjoco/dexjoco/tasks/obs_adapters.py
+++ b/dexjoco/dexjoco/tasks/obs_adapters.py
@@ -29,9 +29,9 @@ class DexjocoObsAdapter(gym.ObservationWrapper):
     def observation(self, obs):
         proprio_values = [np.asarray(obs["state"][key]).ravel() for key in self.proprio_keys]
         if proprio_values:
-            flat_state = np.concatenate(proprio_values, axis=0).astype(np.float32, copy=False)
+            flat_state = np.concatenate(proprio_values, axis=0).astype(np.float64, copy=False)
         else:
-            flat_state = np.zeros((0,), dtype=np.float32)
+            flat_state = np.zeros((0,), dtype=np.float64)
         return {"state": flat_state, **obs.get("images", {})}
 
     def reset(self, **kwargs):

--- a/dexjoco/dexjoco/tasks/pick_bucket/config.py
+++ b/dexjoco/dexjoco/tasks/pick_bucket/config.py
@@ -14,8 +14,8 @@ class TaskConfig(TaskConfigBase):
     proprio_keys = [
         "tcp_pose",
         "gripper_pose",
-        "boxed_food_ori_pose",
         "bucket_ori_pose",
+        "boxed_food_ori_pose",
         "table_delta_height",
     ]
     teleop = SingleArmTeleopConfig(pose_scale=2.0)

--- a/dexjoco/dexjoco/tasks/state_restorers.py
+++ b/dexjoco/dexjoco/tasks/state_restorers.py
@@ -1,0 +1,270 @@
+"""Per-task helpers that patch a freshly reset env to match a recorded state[0].
+
+`restore_initial_state` is the public entry point used by the replay script: it
+splits the recorded flat proprio vector by `config.proprio_keys`, dispatches to
+the task-specific restorer, runs an `mj_forward`, and returns the refreshed
+wrapped observation.
+
+Each restorer only writes the fields recorded as proprio (object poses + table
+height). Everything else (lighting, table texture, third-person camera) is left
+to whatever `env.reset()` produced, so visual randomization stays effective.
+"""
+
+import mujoco
+import numpy as np
+
+
+def _split_state_by_proprio(state_vec, proprio_keys, ref_state):
+    """Split a flat proprio vector back into a {proprio_key: array} dict.
+
+    Sizes come from a fresh `_compute_observation()` sample because some envs
+    declare e.g. `gripper_pose` as `(1,)` in `observation_space` while actually
+    returning a 16-d sensor vector; `DexjocoObsAdapter` flattens the real
+    array, not the spec.
+    """
+    parts = {}
+    offset = 0
+    for key in proprio_keys:
+        size = max(1, np.asarray(ref_state[key]).ravel().size)
+        parts[key] = np.asarray(state_vec[offset : offset + size], dtype=np.float64)
+        offset += size
+    return parts
+
+
+def _apply_delta_h(raw_env, delta_h):
+    """Mimic each env's table-height adjustment based on what attributes it caches."""
+    raw_env.delta_h = np.float64(delta_h)
+    z0 = getattr(raw_env, "_table_body_z0", None)
+    if z0 is None:
+        z0 = raw_env._table_z
+    table_body_id = raw_env._model.body("table").id
+    raw_env._model.body_pos[table_body_id, 2] = z0 + delta_h
+
+    # Resolve which leg geoms to adjust:
+    #   - most envs cache `_table_leg_geom_ids` (either hardcoded or discovered)
+    #   - water_plant caches `_table_leg_half_len0` keyed by leg name instead
+    #   - bimanual_microwave_cook caches neither and iterates 4 hardcoded names
+    if hasattr(raw_env, "_table_leg_geom_ids"):
+        leg_gids = list(raw_env._table_leg_geom_ids)
+    else:
+        h0_map = getattr(raw_env, "_table_leg_half_len0", None)
+        if isinstance(h0_map, dict) and h0_map and isinstance(next(iter(h0_map)), str):
+            leg_gids = [raw_env._model.geom(n).id for n in h0_map]
+        else:
+            leg_gids = [
+                raw_env._model.geom(n).id
+                for n in ("table_leg_1", "table_leg_2", "table_leg_3", "table_leg_4")
+            ]
+
+    if hasattr(raw_env, "_model_geom_pos0"):
+        # bimanual_microwave_cook / bimanual_unlock_ipad: shift center down and extend size by half.
+        for gid in leg_gids:
+            raw_env._model.geom_pos[gid, 2] = raw_env._model_geom_pos0[gid, 2] - 0.5 * delta_h
+            raw_env._model.geom_size[gid, 1] = raw_env._model_geom_size0[gid, 1] + 0.5 * delta_h
+        return
+
+    # Standard style: extend each leg by the full delta.
+    h0_map = raw_env._table_leg_half_len0
+    for gid in leg_gids:
+        if gid in h0_map:
+            h0 = h0_map[gid]
+        else:
+            name = mujoco.mj_id2name(raw_env._model, mujoco.mjtObj.mjOBJ_GEOM, gid)
+            h0 = h0_map[name]
+        raw_env._model.geom_size[gid, 1] = h0 + delta_h
+
+
+def _restore_water_plant(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    spray = parts["spray_ori_pose"]
+    raw_env._data.jnt("spray_root").qpos[:3] = spray[:3]
+    raw_env._data.jnt("spray_root").qpos[3:7] = spray[3:7]
+    raw_env._spray_ori_pose = spray.copy()
+    plant = parts["plant_ori_pose"]
+    raw_env._model.body("plant").pos = plant[:3]
+    raw_env._plant_ori_pose = plant.copy()
+
+
+def _restore_click_mouse(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    mouse = parts["mouse_ori_pose"]
+    raw_env._data.jnt("mouse_root").qpos = mouse
+    raw_env.mouse_ori_pose = mouse.copy()
+    # env.reset() ties the mousepad's xy to the freshly-sampled mouse_xy;
+    # after restoring the mouse to the recorded pose, re-attach the
+    # mousepad so the rigid-body contact graph matches.
+    from ..sim.envs.panda_click_mouse_env import _MOUSEPAD_OFFSET
+    mujoco.mj_forward(raw_env._model, raw_env._data)
+    table_z = float(raw_env._data.site_xpos[raw_env._table_site_id][2])
+    raw_env._model.body_pos[raw_env._mousepad_body_id][:3] = (
+        np.array([mouse[0], mouse[1], table_z]) + _MOUSEPAD_OFFSET
+    )
+    # The monitor (display_root) has a free joint with `z = z0 + delta_h`;
+    # reset() sampled this z with the original delta_h, but `_apply_delta_h`
+    # above just rewrote `raw_env.delta_h` to the recorded value, leaving
+    # the monitor floating or buried by `(delta_h_original - delta_h_recorded)`.
+    # Its xy stays as whatever reset() sampled (not in proprio).
+    raw_env._data.jnt("display_root").qpos[2] = (
+        raw_env._display_root_z0 + raw_env.delta_h
+    )
+
+
+def _restore_pinch_tongs(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    tongs = parts["tongs_ori_pose"]
+    raw_env._data.jnt("tongs_root").qpos = tongs
+    raw_env.tongs_ori_pose = tongs.copy()
+
+
+def _restore_fold_glasses(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    glass = parts["glass_ori_pose"]
+    raw_env._data.jnt("glass_root").qpos = glass
+    raw_env.glass_ori_pose = glass.copy()
+    box = parts["box_ori_pose"]
+    box_body_id = raw_env._model.body("open_box").id
+    raw_env._model.body_pos[box_body_id] = box[:3]
+    raw_env._model.body_quat[box_body_id] = box[3:7]
+    raw_env.open_box_ori_pose = box.copy()
+
+
+def _restore_hammer_nail(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    raw_env._model.body_pos[raw_env._model.body("wood").id, 2] = (
+        raw_env._wood_body_z0 + raw_env.delta_h
+    )
+    hammer = parts["hammer_ori_pose"]
+    raw_env._data.jnt("hammer_joint").qpos = hammer
+    raw_env.hammer_ori_pose = hammer.copy()
+    nail = parts["nail_ori_pose"]
+    nail_pos = nail[:3].copy()
+    nail_pos[2] = raw_env._nail_body_z0 + raw_env.delta_h
+    raw_env._nail_init_pos[:] = nail_pos
+    raw_env._data.mocap_pos[raw_env._nail_mocap_id] = nail_pos
+    raw_env._data.mocap_quat[raw_env._nail_mocap_id] = nail[3:7]
+    raw_env.nail_ori_pose = np.concatenate([nail_pos, nail[3:7]])
+
+
+def _restore_pick_bucket(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    bucket = parts["bucket_ori_pose"]
+    raw_env._data.jnt("bucket_root").qpos = bucket
+    raw_env.bucket_ori_pose = bucket.copy()
+    raw_env._bucket_z = float(bucket[2])
+    boxed_food = parts["boxed_food_ori_pose"]
+    raw_env._data.jnt("boxed_food_0_freejoint").qpos = boxed_food
+    raw_env.box_food_ori_pose = boxed_food.copy()
+    # Re-baseline `_bucket_bottom_z0`: env.reset() captures it at the
+    # randomly-sampled bucket pose, but success uses (bottom_z - z0 >= 0.15)
+    # so the baseline must reflect the restored bucket pose.
+    mujoco.mj_forward(raw_env._model, raw_env._data)
+    raw_env._bucket_bottom_z0 = raw_env._data.site_xpos[
+        raw_env._bucket_bottom_site_ids, 2
+    ].copy()
+
+
+def _restore_bimanual_assembly(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    socket = parts["socket_ori_pose"]
+    raw_env._set_free_joint_pose(
+        raw_env._socket_qpos_adr, raw_env._socket_qvel_adr, socket[:3], socket[3:7]
+    )
+    raw_env._socket_ori_pose = socket.copy()
+    peg = parts["peg_ori_pose"]
+    raw_env._set_free_joint_pose(
+        raw_env._peg_qpos_adr, raw_env._peg_qvel_adr, peg[:3], peg[3:7]
+    )
+    raw_env._peg_ori_pose = peg.copy()
+
+
+def _restore_bimanual_hanoi(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    base = np.asarray(parts["hanoi_base_ori_pos"], dtype=np.float64)
+    raw_env._model.body_pos[raw_env._base_body_id] = base
+    raw_env.base_ori_pos = base.copy()
+    # Re-stack disks at the recorded base position; the tower preset matches
+    # what reset() would pick, but we need to recompute it relative to the
+    # restored base position (otherwise disks float above the prior location).
+    base_delta_xy = base[:2] - raw_env._base_init_pos[:2]
+    _, tower_state = raw_env._sample_reset_tower_state()
+    raw_env._apply_reset_tower_state(tower_state, base_delta_xy)
+
+
+def _restore_bimanual_microwave_cook(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    hot_dog = parts["hot_dog_ori_pose"]
+    raw_env._data.jnt("hot_dog_free").qpos = hot_dog
+    raw_env._hot_dog_ori_pose = hot_dog.copy()
+    microwave = parts["microwave_ori_pose"]
+    raw_env._model.body("microwave_object").pos = microwave[:3]
+    raw_env._model.body("microwave_object").quat = microwave[3:7]
+    raw_env._microwave_ori_pose = microwave.copy()
+
+
+def _restore_bimanual_photograph(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    # The target_region geom is reset to (logo_pos + constant offset); preserve
+    # that constant offset when we move the logo to the recorded pose.
+    target_offset = (
+        raw_env._model.geom_pos[raw_env._target_region_geom_id]
+        - raw_env._model.geom_pos[raw_env._logo_geom_id]
+    ).copy()
+    logo = parts["logo_ori_pose"]
+    raw_env._model.geom_pos[raw_env._logo_geom_id] = logo[:3]
+    raw_env._model.geom_quat[raw_env._logo_geom_id] = logo[3:7]
+    raw_env._model.geom_pos[raw_env._target_region_geom_id] = logo[:3] + target_offset
+    raw_env.logo_ori_pose = logo.copy()
+    camera = parts["camera_ori_pose"]
+    raw_env._data.jnt("camera_root").qpos = camera
+    raw_env.camera_ori_pose = camera.copy()
+
+
+def _restore_bimanual_unlock_ipad(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    stand = parts["stand_ori_pose"]
+    stand_body_id = raw_env._model.body("ipad_stand").id
+    raw_env._model.body_pos[stand_body_id] = stand[:3]
+    raw_env._stand_ori_pose = stand.copy()
+    ipad = parts["ipad_ori_pose"]
+    raw_env._data.jnt("ipad_freejoint").qpos[:3] = ipad[:3]
+    raw_env._ipad_ori_pose = ipad.copy()
+
+
+_STATE_RESTORERS = {
+    "water_plant": _restore_water_plant,
+    "click_mouse": _restore_click_mouse,
+    "pinch_tongs": _restore_pinch_tongs,
+    "fold_glasses": _restore_fold_glasses,
+    "hammer_nail": _restore_hammer_nail,
+    "pick_bucket": _restore_pick_bucket,
+    "bimanual_assembly": _restore_bimanual_assembly,
+    "bimanual_hanoi": _restore_bimanual_hanoi,
+    "bimanual_microwave_cook": _restore_bimanual_microwave_cook,
+    "bimanual_photograph": _restore_bimanual_photograph,
+    "bimanual_unlock_ipad": _restore_bimanual_unlock_ipad,
+}
+
+
+def has_restorer(task_id):
+    """True if `task_id` has a registered initial-state restorer."""
+    return task_id in _STATE_RESTORERS
+
+
+def restore_initial_state(env, task_id, config, state_vec):
+    """Patch a freshly reset env to match the recorded `state[0]`.
+
+    Args:
+        env: a wrapped env (e.g. the one returned by `TaskConfig.get_environment`).
+        task_id: key into the task registry; must satisfy `has_restorer(task_id)`.
+        config: the matching `TaskConfig` (used for `proprio_keys`).
+        state_vec: 1-D recorded proprio vector for `t = 0`.
+
+    Returns:
+        The refreshed wrapped observation produced after the restore + mj_forward.
+    """
+    raw_env = env.unwrapped
+    ref_state = raw_env._compute_observation()["state"]
+    parts = _split_state_by_proprio(state_vec, config.proprio_keys, ref_state)
+    _STATE_RESTORERS[task_id](raw_env, parts)
+    mujoco.mj_forward(raw_env._model, raw_env._data)
+    return env.observation(raw_env._compute_observation())

--- a/scripts/record_demos_zarr.py
+++ b/scripts/record_demos_zarr.py
@@ -17,6 +17,7 @@ import zarr
 from absl import app, flags
 
 # Project-specific utilities for replay storage and video writing.
+from dexjoco.data.depth_capture import collect_depth_frames, write_depth_outputs
 from dexjoco.data.episode_store import ZarrEpisodeStore
 from dexjoco.data.video_writer import Mp4VideoWriter
 from dexjoco.tasks.mappings import CONFIG_MAPPING
@@ -53,6 +54,11 @@ flags.DEFINE_bool(
     "randomize",
     False,
     "Enable environment randomization when the selected task supports it",
+)
+flags.DEFINE_bool(
+    "save_depth",
+    False,
+    "Also render a depth_array per RGB camera and save <cam>_depth.npz + .mp4 alongside each video",
 )
 
 
@@ -394,6 +400,15 @@ def _write_demo_zarr_and_videos(
         video_writer.stop()
         print(f"[Saved video] {out_path}")
 
+    if FLAGS.save_depth:
+        depth_per_camera = {k: [] for k in camera_keys}
+        for step in trajectory:
+            for k, frame in step.get("depth", {}).items():
+                if k in depth_per_camera and frame is not None:
+                    depth_per_camera[k].append(frame)
+        for path in write_depth_outputs(depth_per_camera, videos_dir, video_fps):
+            print(f"[Saved depth]  {path}")
+
     return str(demo_dir)
 
 
@@ -445,6 +460,17 @@ def main(_argv):
     while success_count < success_needed:
         actions = np.zeros(env.action_space.sample().shape)
 
+        # Capture depth now (env state currently matches `obs`); it'll be
+        # stored alongside `obs` below for parity with the RGB cameras.
+        depth_now = None
+        if FLAGS.save_depth and isinstance(obs, dict):
+            obs_image_keys = [
+                k for k, v in obs.items()
+                if k not in ("state", "low_dim")
+                and isinstance(v, np.ndarray) and v.ndim >= 3 and v.shape[-1] == 3
+            ]
+            depth_now = collect_depth_frames(env, obs_image_keys)
+
         if (
             FLAGS.show_sim_cameras
             and wrist_cam_viewer is None
@@ -472,6 +498,8 @@ def main(_argv):
         transition = copy.deepcopy(
             dict(observations=obs, actions=actions, dones=done, infos=info)
         )
+        if depth_now is not None:
+            transition["depth"] = depth_now
         trajectory.append(transition)
 
         pbar.set_description(f"Return: {returns}")

--- a/scripts/replay_demos_zarr.py
+++ b/scripts/replay_demos_zarr.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python3
+"""
+Replay previously recorded Zarr demos under the policy interface and save the
+result as a fresh Zarr episode plus MP4 videos.
+
+For each input demo directory containing a `replay.zarr`, the script writes:
+- `<exp_name>_demo_<index>_replay_<timestamp>/replay.zarr/`
+- `<exp_name>_demo_<index>_replay_<timestamp>/videos/<camera_key>.mp4`
+
+The script plays the recorded action sequence on a freshly reset environment
+constructed via `TaskConfig.get_environment(policy_mode=True, ...)`. With
+`--randomize=True`, the underlying task draws a new preset camera from
+`dexjoco/sim/envs/replay_cameras.npy` plus randomized lighting/texture, which
+makes this useful for visual augmentation of an existing dataset.
+
+When `--restore_state=True` (default), `state[0]` from the input zarr is sliced
+by the task's `proprio_keys` and the env's initial object poses + table height
+are patched back to match the recording.
+"""
+
+import copy
+import datetime
+from pathlib import Path
+
+import mujoco
+import numpy as np
+import zarr
+from absl import app, flags
+from scipy.spatial.transform import Rotation
+from tqdm import tqdm
+
+from dexjoco.data.episode_store import ZarrEpisodeStore
+from dexjoco.data.video_writer import Mp4VideoWriter
+from dexjoco.tasks.mappings import CONFIG_MAPPING
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string(
+    "exp_name",
+    "water_plant",
+    "Task name, such as water_plant.",
+)
+flags.DEFINE_string(
+    "input_dir",
+    "./",
+    "Directory containing recorded demo folders (each holds a replay.zarr).",
+)
+flags.DEFINE_string(
+    "out_dir",
+    "./replay_output",
+    "Output base directory for the new zarr and videos.",
+)
+flags.DEFINE_integer("video_fps", 30, "FPS for saved MP4 videos")
+flags.DEFINE_float(
+    "data_fps",
+    30,
+    "Sampling frequency of recorded low-dim data in Hz (used to write timestamps)",
+)
+flags.DEFINE_bool(
+    "randomize",
+    True,
+    "Enable environment randomization (random preset camera, lighting, texture) at reset",
+)
+flags.DEFINE_integer(
+    "seed",
+    0,
+    "Base seed for the replay environment; the demo index is added per demo",
+)
+flags.DEFINE_integer(
+    "extend_steps",
+    60,
+    "Extra steps to repeat the last action after the recorded trajectory ends",
+)
+flags.DEFINE_bool(
+    "save_failed",
+    False,
+    "Save the replayed demo even when the environment does not report success",
+)
+flags.DEFINE_bool(
+    "restore_state",
+    True,
+    "Restore the recorded initial scene state (table height + object poses) from state[0]",
+)
+
+
+def _safe_squeeze_image(img: np.ndarray) -> np.ndarray:
+    """Squeeze common single-batch dimensions and ensure HWC uint8 RGB."""
+    if img is None:
+        return None
+    arr = np.asarray(img)
+    if arr.ndim == 4 and arr.shape[0] == 1:
+        arr = arr[0]
+    if arr.ndim == 2:
+        arr = np.stack([arr] * 3, axis=-1)
+    if arr.ndim == 3 and arr.shape[2] == 1:
+        arr = np.concatenate([arr, arr, arr], axis=2)
+    if arr.dtype != np.uint8:
+        if np.issubdtype(arr.dtype, np.floating):
+            if np.nanmax(arr) <= 1.0:
+                arr = np.clip(arr, 0.0, 1.0) * 255.0
+            else:
+                arr = np.clip(arr, 0.0, 255.0)
+            arr = arr.astype(np.uint8)
+        else:
+            arr = arr.astype(np.uint8)
+    return arr
+
+
+def convert_action_quat_to_rotvec(action: np.ndarray) -> np.ndarray:
+    """Convert action quaternions from wxyz to rotation vectors.
+
+    Supported layouts:
+      - single-arm 23-d: [pos3, quat4, 16 joints] -> 22-d
+      - bimanual 46-d: [right23, left23] -> 44-d
+    """
+    action = np.asarray(action)
+    if action.ndim != 1:
+        return None
+
+    def _convert_single_arm(single_arm_action: np.ndarray) -> np.ndarray:
+        pos = single_arm_action[0:3]
+        quat = single_arm_action[3:7].astype(np.float64)
+        hand_joints = single_arm_action[7:23]
+
+        norm = np.linalg.norm(quat)
+        if norm < 1e-8:
+            rotvec = np.zeros(3, dtype=np.float64)
+        else:
+            quat = quat / norm
+            quat_xyzw = [quat[1], quat[2], quat[3], quat[0]]
+            rotvec = Rotation.from_quat(quat_xyzw).as_rotvec()
+
+        return np.concatenate([pos, rotvec, hand_joints])
+
+    if action.shape[0] == 23:
+        return _convert_single_arm(action)
+    if action.shape[0] == 46:
+        return np.concatenate(
+            [
+                _convert_single_arm(action[:23]),
+                _convert_single_arm(action[23:46]),
+            ],
+            axis=0,
+        )
+    return None
+
+
+def _load_episode_actions(zarr_path: Path) -> np.ndarray:
+    """Read the recorded action array for a single-episode demo zarr."""
+    root = zarr.open(str(zarr_path), mode="r")
+    return np.asarray(root["data"]["action"])
+
+
+def _load_episode_initial_state(zarr_path: Path):
+    """Read state[0] for a single-episode demo zarr, or None if not stored."""
+    root = zarr.open(str(zarr_path), mode="r")
+    if "state" not in root["data"]:
+        return None
+    return np.asarray(root["data"]["state"][0]).ravel()
+
+
+def _split_state_by_proprio(state_vec: np.ndarray, proprio_keys, ref_state: dict) -> dict:
+    """Split the flat recorded state vector back into a {proprio_key: array} dict.
+
+    Uses sizes from a fresh `_compute_observation()` sample because some envs declare
+    `gripper_pose` as shape `(1,)` in `observation_space` while actually returning a
+    16-d sensor vector; `DexjocoObsAdapter` flattens the real array, not the spec.
+    """
+    parts = {}
+    offset = 0
+    for key in proprio_keys:
+        size = max(1, np.asarray(ref_state[key]).ravel().size)
+        parts[key] = np.asarray(state_vec[offset : offset + size], dtype=np.float64)
+        offset += size
+    return parts
+
+
+def _apply_delta_h(raw_env, delta_h: float) -> None:
+    """Mimic each env's table-height adjustment based on what attributes it caches."""
+    raw_env.delta_h = np.float64(delta_h)
+    z0 = getattr(raw_env, "_table_body_z0", None)
+    if z0 is None:
+        z0 = raw_env._table_z
+    table_body_id = raw_env._model.body("table").id
+    raw_env._model.body_pos[table_body_id, 2] = z0 + delta_h
+
+    # Resolve which leg geoms to adjust:
+    #   - most envs cache `_table_leg_geom_ids` (either hardcoded or discovered)
+    #   - water_plant caches `_table_leg_half_len0` keyed by leg name instead
+    #   - bimanual_microwave_cook caches neither and iterates 4 hardcoded names
+    if hasattr(raw_env, "_table_leg_geom_ids"):
+        leg_gids = list(raw_env._table_leg_geom_ids)
+    else:
+        h0_map = getattr(raw_env, "_table_leg_half_len0", None)
+        if isinstance(h0_map, dict) and h0_map and isinstance(next(iter(h0_map)), str):
+            leg_gids = [raw_env._model.geom(n).id for n in h0_map]
+        else:
+            leg_gids = [
+                raw_env._model.geom(n).id
+                for n in ("table_leg_1", "table_leg_2", "table_leg_3", "table_leg_4")
+            ]
+
+    if hasattr(raw_env, "_model_geom_pos0"):
+        # bimanual_microwave_cook / bimanual_unlock_ipad: shift center down and extend size by half.
+        for gid in leg_gids:
+            raw_env._model.geom_pos[gid, 2] = raw_env._model_geom_pos0[gid, 2] - 0.5 * delta_h
+            raw_env._model.geom_size[gid, 1] = raw_env._model_geom_size0[gid, 1] + 0.5 * delta_h
+        return
+
+    # Standard style: extend each leg by the full delta.
+    h0_map = raw_env._table_leg_half_len0
+    for gid in leg_gids:
+        if gid in h0_map:
+            h0 = h0_map[gid]
+        else:
+            name = mujoco.mj_id2name(raw_env._model, mujoco.mjtObj.mjOBJ_GEOM, gid)
+            h0 = h0_map[name]
+        raw_env._model.geom_size[gid, 1] = h0 + delta_h
+
+
+def _restore_water_plant(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    spray = parts["spray_ori_pose"]
+    raw_env._data.jnt("spray_root").qpos[:3] = spray[:3]
+    raw_env._data.jnt("spray_root").qpos[3:7] = spray[3:7]
+    raw_env._spray_ori_pose = spray.copy()
+    plant = parts["plant_ori_pose"]
+    raw_env._model.body("plant").pos = plant[:3]
+    raw_env._plant_ori_pose = plant.copy()
+
+
+def _restore_click_mouse(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    mouse = parts["mouse_ori_pose"]
+    raw_env._data.jnt("mouse_root").qpos = mouse
+    raw_env.mouse_ori_pose = mouse.copy()
+
+
+def _restore_pinch_tongs(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    tongs = parts["tongs_ori_pose"]
+    raw_env._data.jnt("tongs_root").qpos = tongs
+    raw_env.tongs_ori_pose = tongs.copy()
+
+
+def _restore_fold_glasses(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    glass = parts["glass_ori_pose"]
+    raw_env._data.jnt("glass_root").qpos = glass
+    raw_env.glass_ori_pose = glass.copy()
+    box = parts["box_ori_pose"]
+    box_body_id = raw_env._model.body("open_box").id
+    raw_env._model.body_pos[box_body_id] = box[:3]
+    raw_env._model.body_quat[box_body_id] = box[3:7]
+    raw_env.open_box_ori_pose = box.copy()
+
+
+def _restore_hammer_nail(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    raw_env._model.body_pos[raw_env._model.body("wood").id, 2] = (
+        raw_env._wood_body_z0 + raw_env.delta_h
+    )
+    hammer = parts["hammer_ori_pose"]
+    raw_env._data.jnt("hammer_joint").qpos = hammer
+    raw_env.hammer_ori_pose = hammer.copy()
+    nail = parts["nail_ori_pose"]
+    nail_pos = nail[:3].copy()
+    nail_pos[2] = raw_env._nail_body_z0 + raw_env.delta_h
+    raw_env._nail_init_pos[:] = nail_pos
+    raw_env._data.mocap_pos[raw_env._nail_mocap_id] = nail_pos
+    raw_env._data.mocap_quat[raw_env._nail_mocap_id] = nail[3:7]
+    raw_env.nail_ori_pose = np.concatenate([nail_pos, nail[3:7]])
+
+
+def _restore_pick_bucket(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    bucket = parts["bucket_ori_pose"]
+    raw_env._data.jnt("bucket_root").qpos = bucket
+    raw_env.bucket_ori_pose = bucket.copy()
+    raw_env._bucket_z = float(bucket[2])
+    boxed_food = parts["boxed_food_ori_pose"]
+    raw_env._data.jnt("boxed_food_0_freejoint").qpos = boxed_food
+    raw_env.box_food_ori_pose = boxed_food.copy()
+    # Re-baseline `_bucket_bottom_z0`: env.reset() captures it at the
+    # randomly-sampled bucket pose, but success uses (bottom_z - z0 >= 0.15)
+    # so the baseline must reflect the restored bucket pose.
+    mujoco.mj_forward(raw_env._model, raw_env._data)
+    raw_env._bucket_bottom_z0 = raw_env._data.site_xpos[
+        raw_env._bucket_bottom_site_ids, 2
+    ].copy()
+
+
+def _restore_bimanual_assembly(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    socket = parts["socket_ori_pose"]
+    raw_env._set_free_joint_pose(
+        raw_env._socket_qpos_adr, raw_env._socket_qvel_adr, socket[:3], socket[3:7]
+    )
+    raw_env._socket_ori_pose = socket.copy()
+    peg = parts["peg_ori_pose"]
+    raw_env._set_free_joint_pose(
+        raw_env._peg_qpos_adr, raw_env._peg_qvel_adr, peg[:3], peg[3:7]
+    )
+    raw_env._peg_ori_pose = peg.copy()
+
+
+def _restore_bimanual_hanoi(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    base = np.asarray(parts["hanoi_base_ori_pos"], dtype=np.float64)
+    raw_env._model.body_pos[raw_env._base_body_id] = base
+    raw_env.base_ori_pos = base.copy()
+    # Re-stack disks at the recorded base position; the tower preset matches
+    # what reset() would pick, but we need to recompute it relative to the
+    # restored base position (otherwise disks float above the prior location).
+    base_delta_xy = base[:2] - raw_env._base_init_pos[:2]
+    _, tower_state = raw_env._sample_reset_tower_state()
+    raw_env._apply_reset_tower_state(tower_state, base_delta_xy)
+
+
+def _restore_bimanual_microwave_cook(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    hot_dog = parts["hot_dog_ori_pose"]
+    raw_env._data.jnt("hot_dog_free").qpos = hot_dog
+    raw_env._hot_dog_ori_pose = hot_dog.copy()
+    microwave = parts["microwave_ori_pose"]
+    raw_env._model.body("microwave_object").pos = microwave[:3]
+    raw_env._model.body("microwave_object").quat = microwave[3:7]
+    raw_env._microwave_ori_pose = microwave.copy()
+
+
+def _restore_bimanual_photograph(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    # The target_region geom is reset to (logo_pos + constant offset); preserve
+    # that constant offset when we move the logo to the recorded pose.
+    target_offset = (
+        raw_env._model.geom_pos[raw_env._target_region_geom_id]
+        - raw_env._model.geom_pos[raw_env._logo_geom_id]
+    ).copy()
+    logo = parts["logo_ori_pose"]
+    raw_env._model.geom_pos[raw_env._logo_geom_id] = logo[:3]
+    raw_env._model.geom_quat[raw_env._logo_geom_id] = logo[3:7]
+    raw_env._model.geom_pos[raw_env._target_region_geom_id] = logo[:3] + target_offset
+    raw_env.logo_ori_pose = logo.copy()
+    camera = parts["camera_ori_pose"]
+    raw_env._data.jnt("camera_root").qpos = camera
+    raw_env.camera_ori_pose = camera.copy()
+
+
+def _restore_bimanual_unlock_ipad(raw_env, parts):
+    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
+    stand = parts["stand_ori_pose"]
+    stand_body_id = raw_env._model.body("ipad_stand").id
+    raw_env._model.body_pos[stand_body_id] = stand[:3]
+    raw_env._stand_ori_pose = stand.copy()
+    ipad = parts["ipad_ori_pose"]
+    raw_env._data.jnt("ipad_freejoint").qpos[:3] = ipad[:3]
+    raw_env._ipad_ori_pose = ipad.copy()
+
+
+_STATE_RESTORERS = {
+    "water_plant": _restore_water_plant,
+    "click_mouse": _restore_click_mouse,
+    "pinch_tongs": _restore_pinch_tongs,
+    "fold_glasses": _restore_fold_glasses,
+    "hammer_nail": _restore_hammer_nail,
+    "pick_bucket": _restore_pick_bucket,
+    "bimanual_assembly": _restore_bimanual_assembly,
+    "bimanual_hanoi": _restore_bimanual_hanoi,
+    "bimanual_microwave_cook": _restore_bimanual_microwave_cook,
+    "bimanual_photograph": _restore_bimanual_photograph,
+    "bimanual_unlock_ipad": _restore_bimanual_unlock_ipad,
+}
+
+
+def _restore_initial_state(env, task_id: str, config, state_vec: np.ndarray):
+    """Patch the freshly reset env to match the recorded state[0] and return refreshed obs."""
+    raw_env = env.unwrapped
+    ref_state = raw_env._compute_observation()["state"]
+    parts = _split_state_by_proprio(state_vec, config.proprio_keys, ref_state)
+    _STATE_RESTORERS[task_id](raw_env, parts)
+    mujoco.mj_forward(raw_env._model, raw_env._data)
+    return env.observation(raw_env._compute_observation())
+
+
+def _step_with_recorded_action(env, action_flat: np.ndarray):
+    """Step the raw env with a recorded action and rewrap the observation.
+
+    Recorded actions are stored in the same layout that the raw bimanual env consumes
+    (``[right(23), left(23)]``), whereas ``DualArmPolicyWrapper`` expects
+    ``[r_pose, l_pose, r_hand, l_hand]``. We bypass the policy wrapper and feed the
+    raw env directly to keep replay faithful to the recording.
+    """
+    raw_env = env.unwrapped
+    action_flat = np.asarray(action_flat, dtype=np.float64)
+    if action_flat.shape == (46,):
+        raw_action = {
+            "right": action_flat[:23],
+            "left": action_flat[23:46],
+        }
+    else:
+        raw_action = action_flat
+    raw_obs, rew, done, trunc, info = raw_env.step(raw_action)
+    return env.observation(raw_obs), rew, done, trunc, info
+
+
+def _collect_camera_keys(observation: dict) -> list:
+    keys = []
+    for k, v in observation.items():
+        if isinstance(v, np.ndarray) and v.ndim >= 3 and v.shape[-1] == 3:
+            keys.append(k)
+    return keys
+
+
+def _write_demo_zarr_and_videos(
+    trajectory, exp_name: str, success_index: int, base_out: Path, video_fps: int
+):
+    """Save one replayed trajectory to a zarr group plus MP4 camera captures."""
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S_%f")
+    demo_dir = base_out / f"{exp_name}_demo_{success_index}_replay_{timestamp}"
+    demo_dir.mkdir(parents=True, exist_ok=True)
+
+    actions = np.stack([t["actions"] for t in trajectory], axis=0)
+    T = actions.shape[0]
+    timestamps_arr = np.arange(T) / float(FLAGS.data_fps)
+
+    episode_data = {
+        "action": actions,
+        "timestamp": timestamps_arr,
+    }
+
+    states = [t["observations"].get("state") for t in trajectory]
+    if all(isinstance(s, np.ndarray) for s in states):
+        try:
+            episode_data["state"] = np.stack(states, axis=0)
+        except ValueError:
+            pass
+
+    converted = [convert_action_quat_to_rotvec(a) for a in actions]
+    if all(c is not None for c in converted):
+        episode_data["action_rotvec"] = np.stack(converted, axis=0)
+
+    zarr_path = demo_dir / "replay.zarr"
+    store = zarr.DirectoryStore(str(zarr_path))
+    episode_store = ZarrEpisodeStore.create_empty(storage=store)
+    episode_store.append_episode(episode_data, compressors="disk")
+    print(f"[Saved replay.zarr] {zarr_path} (steps: {T})")
+
+    videos_dir = demo_dir / "videos"
+    videos_dir.mkdir(parents=True, exist_ok=True)
+
+    camera_keys = []
+    for step in trajectory:
+        for k in _collect_camera_keys(step["observations"]):
+            if k not in camera_keys:
+                camera_keys.append(k)
+
+    for cam_key in camera_keys:
+        video_writer = Mp4VideoWriter.create_h264(
+            fps=video_fps,
+            codec="h264",
+            input_pix_fmt="rgb24",
+            crf=21,
+            thread_type="FRAME",
+            thread_count=2,
+        )
+        out_path = str(videos_dir / f"{cam_key}.mp4")
+        video_writer.start(out_path)
+
+        for step in trajectory:
+            img = step["observations"].get(cam_key)
+            if img is None:
+                continue
+            video_writer.write_frame(_safe_squeeze_image(img))
+
+        video_writer.stop()
+        print(f"[Saved video] {out_path}")
+
+    return str(demo_dir)
+
+
+def _replay_single_demo(
+    actions: np.ndarray,
+    initial_state: np.ndarray,
+    task_id: str,
+    config,
+    env_seed: int,
+    desc: str,
+):
+    env = config.get_environment(
+        policy_mode=True,
+        render_mode="rgb_array",
+        randomize=FLAGS.randomize,
+        randomize_dynamics=False,
+        seed=env_seed,
+    )
+    try:
+        obs, _info = env.reset()
+
+        if FLAGS.restore_state and initial_state is not None and task_id in _STATE_RESTORERS:
+            obs = _restore_initial_state(env, task_id, config, initial_state)
+
+        trajectory = []
+        succeed = False
+        num_steps = actions.shape[0]
+        total_steps = num_steps + max(0, FLAGS.extend_steps)
+
+        for step_idx in tqdm(range(total_steps), desc=desc):
+            action = actions[step_idx if step_idx < num_steps else -1]
+            next_obs, _rew, done, _trunc, info = _step_with_recorded_action(env, action)
+            trajectory.append(
+                copy.deepcopy(
+                    dict(observations=obs, actions=action, dones=done, infos=info)
+                )
+            )
+            obs = next_obs
+            if info.get("succeed", False):
+                succeed = True
+    finally:
+        try:
+            env.close()
+        except Exception:
+            pass
+
+    return succeed, trajectory
+
+
+def main(_argv):
+    task_id = FLAGS.exp_name
+    config = CONFIG_MAPPING[task_id]()
+
+    base_out = Path(FLAGS.out_dir)
+    base_out.mkdir(parents=True, exist_ok=True)
+
+    input_root = Path(FLAGS.input_dir)
+    demo_dirs = sorted(p.parent for p in input_root.glob("*/replay.zarr"))
+    if not demo_dirs:
+        print(f"No replay.zarr found under {input_root}")
+        return
+
+    saved_demo_dirs = []
+    for index, demo_dir in enumerate(demo_dirs, start=1):
+        print(f"\n[{index}/{len(demo_dirs)}] {demo_dir.name}")
+        zarr_path = demo_dir / "replay.zarr"
+        actions = _load_episode_actions(zarr_path)
+        initial_state = _load_episode_initial_state(zarr_path)
+        if FLAGS.restore_state and initial_state is None:
+            print("[Warning] state[0] not found in input zarr; replay will use the reset scene as-is.")
+
+        succeed, trajectory = _replay_single_demo(
+            actions, initial_state, task_id, config,
+            env_seed=FLAGS.seed + index, desc=demo_dir.name,
+        )
+        print(f"Replay finished: succeed={succeed}, steps={len(trajectory)}")
+
+        if not trajectory:
+            continue
+        if not (succeed or FLAGS.save_failed):
+            print("[Skipped] env did not report success; pass --save_failed to keep.")
+            continue
+
+        saved = _write_demo_zarr_and_videos(
+            trajectory, task_id, index, base_out, FLAGS.video_fps
+        )
+        saved_demo_dirs.append(saved)
+
+    print(f"\nReplayed {len(saved_demo_dirs)}/{len(demo_dirs)} demos:")
+    for p in saved_demo_dirs:
+        print("  ", p)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/scripts/replay_demos_zarr.py
+++ b/scripts/replay_demos_zarr.py
@@ -13,16 +13,16 @@ constructed via `TaskConfig.get_environment(policy_mode=True, ...)`. With
 `dexjoco/sim/envs/replay_cameras.npy` plus randomized lighting/texture, which
 makes this useful for visual augmentation of an existing dataset.
 
-When `--restore_state=True` (default), `state[0]` from the input zarr is sliced
-by the task's `proprio_keys` and the env's initial object poses + table height
-are patched back to match the recording.
+When `--restore_state=True` (default), `state[0]` from the input zarr is
+sliced by the task's `proprio_keys` and the env's initial object poses +
+table height are patched back to match the recording. The per-task restorers
+live in `dexjoco.tasks.state_restorers`.
 """
 
 import copy
 import datetime
 from pathlib import Path
 
-import mujoco
 import numpy as np
 import zarr
 from absl import app, flags
@@ -32,6 +32,7 @@ from tqdm import tqdm
 from dexjoco.data.episode_store import ZarrEpisodeStore
 from dexjoco.data.video_writer import Mp4VideoWriter
 from dexjoco.tasks.mappings import CONFIG_MAPPING
+from dexjoco.tasks.state_restorers import has_restorer, restore_initial_state
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string(
@@ -158,229 +159,6 @@ def _load_episode_initial_state(zarr_path: Path):
     return np.asarray(root["data"]["state"][0]).ravel()
 
 
-def _split_state_by_proprio(state_vec: np.ndarray, proprio_keys, ref_state: dict) -> dict:
-    """Split the flat recorded state vector back into a {proprio_key: array} dict.
-
-    Uses sizes from a fresh `_compute_observation()` sample because some envs declare
-    `gripper_pose` as shape `(1,)` in `observation_space` while actually returning a
-    16-d sensor vector; `DexjocoObsAdapter` flattens the real array, not the spec.
-    """
-    parts = {}
-    offset = 0
-    for key in proprio_keys:
-        size = max(1, np.asarray(ref_state[key]).ravel().size)
-        parts[key] = np.asarray(state_vec[offset : offset + size], dtype=np.float64)
-        offset += size
-    return parts
-
-
-def _apply_delta_h(raw_env, delta_h: float) -> None:
-    """Mimic each env's table-height adjustment based on what attributes it caches."""
-    raw_env.delta_h = np.float64(delta_h)
-    z0 = getattr(raw_env, "_table_body_z0", None)
-    if z0 is None:
-        z0 = raw_env._table_z
-    table_body_id = raw_env._model.body("table").id
-    raw_env._model.body_pos[table_body_id, 2] = z0 + delta_h
-
-    # Resolve which leg geoms to adjust:
-    #   - most envs cache `_table_leg_geom_ids` (either hardcoded or discovered)
-    #   - water_plant caches `_table_leg_half_len0` keyed by leg name instead
-    #   - bimanual_microwave_cook caches neither and iterates 4 hardcoded names
-    if hasattr(raw_env, "_table_leg_geom_ids"):
-        leg_gids = list(raw_env._table_leg_geom_ids)
-    else:
-        h0_map = getattr(raw_env, "_table_leg_half_len0", None)
-        if isinstance(h0_map, dict) and h0_map and isinstance(next(iter(h0_map)), str):
-            leg_gids = [raw_env._model.geom(n).id for n in h0_map]
-        else:
-            leg_gids = [
-                raw_env._model.geom(n).id
-                for n in ("table_leg_1", "table_leg_2", "table_leg_3", "table_leg_4")
-            ]
-
-    if hasattr(raw_env, "_model_geom_pos0"):
-        # bimanual_microwave_cook / bimanual_unlock_ipad: shift center down and extend size by half.
-        for gid in leg_gids:
-            raw_env._model.geom_pos[gid, 2] = raw_env._model_geom_pos0[gid, 2] - 0.5 * delta_h
-            raw_env._model.geom_size[gid, 1] = raw_env._model_geom_size0[gid, 1] + 0.5 * delta_h
-        return
-
-    # Standard style: extend each leg by the full delta.
-    h0_map = raw_env._table_leg_half_len0
-    for gid in leg_gids:
-        if gid in h0_map:
-            h0 = h0_map[gid]
-        else:
-            name = mujoco.mj_id2name(raw_env._model, mujoco.mjtObj.mjOBJ_GEOM, gid)
-            h0 = h0_map[name]
-        raw_env._model.geom_size[gid, 1] = h0 + delta_h
-
-
-def _restore_water_plant(raw_env, parts):
-    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
-    spray = parts["spray_ori_pose"]
-    raw_env._data.jnt("spray_root").qpos[:3] = spray[:3]
-    raw_env._data.jnt("spray_root").qpos[3:7] = spray[3:7]
-    raw_env._spray_ori_pose = spray.copy()
-    plant = parts["plant_ori_pose"]
-    raw_env._model.body("plant").pos = plant[:3]
-    raw_env._plant_ori_pose = plant.copy()
-
-
-def _restore_click_mouse(raw_env, parts):
-    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
-    mouse = parts["mouse_ori_pose"]
-    raw_env._data.jnt("mouse_root").qpos = mouse
-    raw_env.mouse_ori_pose = mouse.copy()
-
-
-def _restore_pinch_tongs(raw_env, parts):
-    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
-    tongs = parts["tongs_ori_pose"]
-    raw_env._data.jnt("tongs_root").qpos = tongs
-    raw_env.tongs_ori_pose = tongs.copy()
-
-
-def _restore_fold_glasses(raw_env, parts):
-    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
-    glass = parts["glass_ori_pose"]
-    raw_env._data.jnt("glass_root").qpos = glass
-    raw_env.glass_ori_pose = glass.copy()
-    box = parts["box_ori_pose"]
-    box_body_id = raw_env._model.body("open_box").id
-    raw_env._model.body_pos[box_body_id] = box[:3]
-    raw_env._model.body_quat[box_body_id] = box[3:7]
-    raw_env.open_box_ori_pose = box.copy()
-
-
-def _restore_hammer_nail(raw_env, parts):
-    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
-    raw_env._model.body_pos[raw_env._model.body("wood").id, 2] = (
-        raw_env._wood_body_z0 + raw_env.delta_h
-    )
-    hammer = parts["hammer_ori_pose"]
-    raw_env._data.jnt("hammer_joint").qpos = hammer
-    raw_env.hammer_ori_pose = hammer.copy()
-    nail = parts["nail_ori_pose"]
-    nail_pos = nail[:3].copy()
-    nail_pos[2] = raw_env._nail_body_z0 + raw_env.delta_h
-    raw_env._nail_init_pos[:] = nail_pos
-    raw_env._data.mocap_pos[raw_env._nail_mocap_id] = nail_pos
-    raw_env._data.mocap_quat[raw_env._nail_mocap_id] = nail[3:7]
-    raw_env.nail_ori_pose = np.concatenate([nail_pos, nail[3:7]])
-
-
-def _restore_pick_bucket(raw_env, parts):
-    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
-    bucket = parts["bucket_ori_pose"]
-    raw_env._data.jnt("bucket_root").qpos = bucket
-    raw_env.bucket_ori_pose = bucket.copy()
-    raw_env._bucket_z = float(bucket[2])
-    boxed_food = parts["boxed_food_ori_pose"]
-    raw_env._data.jnt("boxed_food_0_freejoint").qpos = boxed_food
-    raw_env.box_food_ori_pose = boxed_food.copy()
-    # Re-baseline `_bucket_bottom_z0`: env.reset() captures it at the
-    # randomly-sampled bucket pose, but success uses (bottom_z - z0 >= 0.15)
-    # so the baseline must reflect the restored bucket pose.
-    mujoco.mj_forward(raw_env._model, raw_env._data)
-    raw_env._bucket_bottom_z0 = raw_env._data.site_xpos[
-        raw_env._bucket_bottom_site_ids, 2
-    ].copy()
-
-
-def _restore_bimanual_assembly(raw_env, parts):
-    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
-    socket = parts["socket_ori_pose"]
-    raw_env._set_free_joint_pose(
-        raw_env._socket_qpos_adr, raw_env._socket_qvel_adr, socket[:3], socket[3:7]
-    )
-    raw_env._socket_ori_pose = socket.copy()
-    peg = parts["peg_ori_pose"]
-    raw_env._set_free_joint_pose(
-        raw_env._peg_qpos_adr, raw_env._peg_qvel_adr, peg[:3], peg[3:7]
-    )
-    raw_env._peg_ori_pose = peg.copy()
-
-
-def _restore_bimanual_hanoi(raw_env, parts):
-    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
-    base = np.asarray(parts["hanoi_base_ori_pos"], dtype=np.float64)
-    raw_env._model.body_pos[raw_env._base_body_id] = base
-    raw_env.base_ori_pos = base.copy()
-    # Re-stack disks at the recorded base position; the tower preset matches
-    # what reset() would pick, but we need to recompute it relative to the
-    # restored base position (otherwise disks float above the prior location).
-    base_delta_xy = base[:2] - raw_env._base_init_pos[:2]
-    _, tower_state = raw_env._sample_reset_tower_state()
-    raw_env._apply_reset_tower_state(tower_state, base_delta_xy)
-
-
-def _restore_bimanual_microwave_cook(raw_env, parts):
-    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
-    hot_dog = parts["hot_dog_ori_pose"]
-    raw_env._data.jnt("hot_dog_free").qpos = hot_dog
-    raw_env._hot_dog_ori_pose = hot_dog.copy()
-    microwave = parts["microwave_ori_pose"]
-    raw_env._model.body("microwave_object").pos = microwave[:3]
-    raw_env._model.body("microwave_object").quat = microwave[3:7]
-    raw_env._microwave_ori_pose = microwave.copy()
-
-
-def _restore_bimanual_photograph(raw_env, parts):
-    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
-    # The target_region geom is reset to (logo_pos + constant offset); preserve
-    # that constant offset when we move the logo to the recorded pose.
-    target_offset = (
-        raw_env._model.geom_pos[raw_env._target_region_geom_id]
-        - raw_env._model.geom_pos[raw_env._logo_geom_id]
-    ).copy()
-    logo = parts["logo_ori_pose"]
-    raw_env._model.geom_pos[raw_env._logo_geom_id] = logo[:3]
-    raw_env._model.geom_quat[raw_env._logo_geom_id] = logo[3:7]
-    raw_env._model.geom_pos[raw_env._target_region_geom_id] = logo[:3] + target_offset
-    raw_env.logo_ori_pose = logo.copy()
-    camera = parts["camera_ori_pose"]
-    raw_env._data.jnt("camera_root").qpos = camera
-    raw_env.camera_ori_pose = camera.copy()
-
-
-def _restore_bimanual_unlock_ipad(raw_env, parts):
-    _apply_delta_h(raw_env, float(parts["table_delta_height"][0]))
-    stand = parts["stand_ori_pose"]
-    stand_body_id = raw_env._model.body("ipad_stand").id
-    raw_env._model.body_pos[stand_body_id] = stand[:3]
-    raw_env._stand_ori_pose = stand.copy()
-    ipad = parts["ipad_ori_pose"]
-    raw_env._data.jnt("ipad_freejoint").qpos[:3] = ipad[:3]
-    raw_env._ipad_ori_pose = ipad.copy()
-
-
-_STATE_RESTORERS = {
-    "water_plant": _restore_water_plant,
-    "click_mouse": _restore_click_mouse,
-    "pinch_tongs": _restore_pinch_tongs,
-    "fold_glasses": _restore_fold_glasses,
-    "hammer_nail": _restore_hammer_nail,
-    "pick_bucket": _restore_pick_bucket,
-    "bimanual_assembly": _restore_bimanual_assembly,
-    "bimanual_hanoi": _restore_bimanual_hanoi,
-    "bimanual_microwave_cook": _restore_bimanual_microwave_cook,
-    "bimanual_photograph": _restore_bimanual_photograph,
-    "bimanual_unlock_ipad": _restore_bimanual_unlock_ipad,
-}
-
-
-def _restore_initial_state(env, task_id: str, config, state_vec: np.ndarray):
-    """Patch the freshly reset env to match the recorded state[0] and return refreshed obs."""
-    raw_env = env.unwrapped
-    ref_state = raw_env._compute_observation()["state"]
-    parts = _split_state_by_proprio(state_vec, config.proprio_keys, ref_state)
-    _STATE_RESTORERS[task_id](raw_env, parts)
-    mujoco.mj_forward(raw_env._model, raw_env._data)
-    return env.observation(raw_env._compute_observation())
-
-
 def _step_with_recorded_action(env, action_flat: np.ndarray):
     """Step the raw env with a recorded action and rewrap the observation.
 
@@ -495,8 +273,8 @@ def _replay_single_demo(
     try:
         obs, _info = env.reset()
 
-        if FLAGS.restore_state and initial_state is not None and task_id in _STATE_RESTORERS:
-            obs = _restore_initial_state(env, task_id, config, initial_state)
+        if FLAGS.restore_state and initial_state is not None and has_restorer(task_id):
+            obs = restore_initial_state(env, task_id, config, initial_state)
 
         trajectory = []
         succeed = False

--- a/scripts/replay_demos_zarr.py
+++ b/scripts/replay_demos_zarr.py
@@ -29,6 +29,7 @@ from absl import app, flags
 from scipy.spatial.transform import Rotation
 from tqdm import tqdm
 
+from dexjoco.data.depth_capture import collect_depth_frames, write_depth_outputs
 from dexjoco.data.episode_store import ZarrEpisodeStore
 from dexjoco.data.video_writer import Mp4VideoWriter
 from dexjoco.tasks.mappings import CONFIG_MAPPING
@@ -80,6 +81,11 @@ flags.DEFINE_bool(
     "restore_state",
     True,
     "Restore the recorded initial scene state (table height + object poses) from state[0]",
+)
+flags.DEFINE_bool(
+    "save_depth",
+    False,
+    "Also render a depth_array per RGB camera and save <cam>_depth.npz + .mp4 alongside each video",
 )
 
 
@@ -252,6 +258,15 @@ def _write_demo_zarr_and_videos(
         video_writer.stop()
         print(f"[Saved video] {out_path}")
 
+    if FLAGS.save_depth:
+        depth_per_camera = {k: [] for k in camera_keys}
+        for step in trajectory:
+            for k, frame in step.get("depth", {}).items():
+                if k in depth_per_camera and frame is not None:
+                    depth_per_camera[k].append(frame)
+        for path in write_depth_outputs(depth_per_camera, videos_dir, video_fps):
+            print(f"[Saved depth]  {path}")
+
     return str(demo_dir)
 
 
@@ -283,12 +298,17 @@ def _replay_single_demo(
 
         for step_idx in tqdm(range(total_steps), desc=desc):
             action = actions[step_idx if step_idx < num_steps else -1]
-            next_obs, _rew, done, _trunc, info = _step_with_recorded_action(env, action)
-            trajectory.append(
-                copy.deepcopy(
-                    dict(observations=obs, actions=action, dones=done, infos=info)
-                )
+            # Capture depth BEFORE step so it lines up with `obs` (which
+            # is what gets stored alongside this transition's action).
+            depth_now = (
+                collect_depth_frames(env, _collect_camera_keys(obs))
+                if FLAGS.save_depth else None
             )
+            next_obs, _rew, done, _trunc, info = _step_with_recorded_action(env, action)
+            transition = dict(observations=obs, actions=action, dones=done, infos=info)
+            if depth_now is not None:
+                transition["depth"] = depth_now
+            trajectory.append(copy.deepcopy(transition))
             obs = next_obs
             if info.get("succeed", False):
                 succeed = True

--- a/scripts/replay_demos_zarr.py
+++ b/scripts/replay_demos_zarr.py
@@ -69,8 +69,11 @@ flags.DEFINE_integer(
 )
 flags.DEFINE_integer(
     "extend_steps",
-    60,
-    "Extra steps to repeat the last action after the recorded trajectory ends",
+    0,
+    "Extra steps to repeat the last action after the recorded trajectory ends. "
+    "Default 0 is fine for demos recorded by record_demos_zarr.py (the saved "
+    "trajectory ends on the succeed step). Set >0 only when replaying older "
+    "data that was clipped before success.",
 )
 flags.DEFINE_bool(
     "save_failed",


### PR DESCRIPTION
## Summary

- Add `scripts/replay_demos_zarr.py`: re-plays demos recorded by `record_demos_zarr.py` against a freshly reset env. Only object poses and table height are restored from `state[0]`; lighting, table texture, and the scene camera stay randomized so the replayed videos are useful as visual augmentation.
- Verified record vs. replay produce **bit-identical physics** across different visual seeds on all 11 tasks (state diff = 0, wrist-camera depth diff = 0; scene-camera depth differs by the intended visual randomization).
- Both scripts grow a `--save_depth` flag (off by default) that writes `<cam>_depth.npz` (float32 metres) + `<cam>_depth.mp4` (gray preview) alongside each RGB video, using MuJoCo's native depth buffer.

## Details

Per-task initial-state restorers live in the new `dexjoco.tasks.state_restorers` module. Beyond restoring proprio fields, the restorers also patch any env-internal state that `env.reset()` sampled but proprio doesn't expose (e.g. mousepad pose in `click_mouse`, monitor z in `click_mouse`, bucket lift baseline in `pick_bucket`, hammer nail z in `hammer_nail`). Several env fixes were needed to make replay tractable:

- `dexjoco/tasks/obs_adapters.py`: keep flattened proprio in float64 instead of float32. The cast lost ~1e-8 per field and the contact solver amplified it to ~1e-2 over a few hundred steps on contact-heavy tasks like `bimanual_microwave_cook`.
- `dexjoco/sim/envs/panda_water_plant_env.py`: stop forcing `table_delta_height` to float32 at observation time (same reason).
- `dexjoco/sim/envs/panda_bimanual_microwave_cook_env.py`: seed `random` and `np.random` from the constructor's `seed` arg, matching the other ten envs. Without this, same-process record/replay tests were sensitive to NumPy global RNG history.
- `dexjoco/tasks/pick_bucket/config.py`: swap `proprio_keys` order from `[boxed_food, bucket]` to `[bucket, boxed_food]`. The reversed order was an outlier vs. the env's own `_compute_observation` dict order and the other ten configs, and caused the restorer to write food into bucket slots and vice versa.

## Test plan

- [x] Replay all 11 task demos in `dexhand_data_example/` end-to-end (`succeed=True` for 11/11).
- [x] Full-trajectory `state` diff between record path and replay path under different visual seeds: 0.0 on all 11 tasks.
- [x] Wrist-camera depth diff (hand-mounted, should track physics): 0.0 on all 11 tasks.
- [x] Scene-camera depth diff (visual randomization actually moves these): non-zero as expected (~3-5 m).
- [x] `--save_depth=True` writes one `.npz` + one `.mp4` per RGB camera; depth values are in metres and have sensible per-task ranges (e.g. wrist ~ 0.08-30 m).
- [x] `--save_depth=False` (default) leaves the existing record/replay output untouched.