### PR TITLE
Add shutter flash + camera-screen-effect toggle to photograph env

### DIFF
--- a/dexjoco/dexjoco/sim/envs/panda_bimanual_photograph_env.py
+++ b/dexjoco/dexjoco/sim/envs/panda_bimanual_photograph_env.py
@@ -244,6 +244,12 @@ class PandaBimanualPhotographGymEnv(MujocoGymEnv):
         self._screen_tex_nchan = 3
         self._init_camera_screen_streaming()
 
+        # Photo capture / flash state.
+        self._capture_flash_total = 5  # ~0.17 s of flash at hz=30
+        self._captured_image = None
+        self._capture_flash_frame = 0
+        self._latest_shutter_pressed = False
+
         self._front_camera_id = int(self._model.camera("back").id)
         self._wrist_left_camera_id = self._get_cam_id_by_name("handcam_rgb_left")
         self._wrist_right_camera_id = self._get_cam_id_by_name("handcam_rgb_right")
@@ -524,35 +530,53 @@ class PandaBimanualPhotographGymEnv(MujocoGymEnv):
         self._screen_tex_nchan = int(self._model.tex_nchannel[tex_id])
 
     def _update_camera_screen_texture(self):
-        """Render cam_pos_z and push the image into the camera_screen_tex texture."""
+        """Drive the camera screen: live preview, capture flash, or frozen photo."""
         if self._screen_tex_id < 0:
             return
-        try:
-            self._set_offscreen_geom_group_visibility(5, False)
-            img = self._viewer.render(
-                render_mode="rgb_array", camera_id=self._screen_cam_id
-            )
-        except Exception:
-            return
-        if img is None or img.ndim != 3 or img.shape[2] < self._screen_tex_nchan:
-            return
 
+        if self._captured_image is None:
+            try:
+                self._set_offscreen_geom_group_visibility(5, False)
+                img = self._viewer.render(
+                    render_mode="rgb_array", camera_id=self._screen_cam_id
+                )
+            except Exception:
+                return
+            if img is None or img.ndim != 3 or img.shape[2] < self._screen_tex_nchan:
+                return
+            img = self._fit_image_to_screen(img)
+
+            if self._latest_shutter_pressed:
+                # First shutter press: cache this frame, start the flash.
+                self._captured_image = img.copy()
+                self._capture_flash_frame = 0
+                final = self._compose_flash_over(img)
+                self._capture_flash_frame += 1
+            else:
+                final = img
+        else:
+            if self._capture_flash_frame < self._capture_flash_total:
+                final = self._compose_flash_over(self._captured_image)
+                self._capture_flash_frame += 1
+            else:
+                final = self._captured_image
+
+        self._write_screen_texture(final)
+
+    def _fit_image_to_screen(self, img: np.ndarray) -> np.ndarray:
+        """Center-crop to the screen aspect ratio and resample to texture size."""
         th, tw = self._screen_tex_h, self._screen_tex_w
         h_in, w_in = img.shape[:2]
 
-        # Center-crop the rendered image to match the texture's aspect ratio
-        # so the camera view isn't stretched on the screen geom.
         tex_aspect = tw / max(th, 1)
         img_aspect = w_in / max(h_in, 1)
         if abs(img_aspect - tex_aspect) > 1e-3:
             if img_aspect > tex_aspect:
-                new_w = int(round(h_in * tex_aspect))
-                new_w = max(1, min(new_w, w_in))
+                new_w = max(1, min(int(round(h_in * tex_aspect)), w_in))
                 x0 = (w_in - new_w) // 2
                 img = img[:, x0:x0 + new_w, :]
             else:
-                new_h = int(round(w_in / tex_aspect))
-                new_h = max(1, min(new_h, h_in))
+                new_h = max(1, min(int(round(w_in / tex_aspect)), h_in))
                 y0 = (h_in - new_h) // 2
                 img = img[y0:y0 + new_h, :, :]
             h_in, w_in = img.shape[:2]
@@ -561,7 +585,19 @@ class PandaBimanualPhotographGymEnv(MujocoGymEnv):
             ys = np.linspace(0, h_in - 1, th).astype(np.int64)
             xs = np.linspace(0, w_in - 1, tw).astype(np.int64)
             img = img[np.ix_(ys, xs)]
+        return img
 
+    def _compose_flash_over(self, base_img: np.ndarray) -> np.ndarray:
+        """Blend a white sheet over the captured image, alpha fading 1 -> 0."""
+        total = max(self._capture_flash_total, 1)
+        progress = min(1.0, self._capture_flash_frame / total)
+        alpha = max(0.0, 1.0 - progress)
+        if alpha <= 0.0:
+            return base_img
+        blended = alpha * 255.0 + (1.0 - alpha) * base_img.astype(np.float32)
+        return np.clip(blended, 0.0, 255.0).astype(np.uint8)
+
+    def _write_screen_texture(self, img: np.ndarray):
         nchan = self._screen_tex_nchan
         flat = np.ascontiguousarray(img[:, :, :nchan], dtype=np.uint8).reshape(-1)
         adr = self._screen_tex_adr
@@ -658,6 +694,11 @@ class PandaBimanualPhotographGymEnv(MujocoGymEnv):
 
     def reset(self, seed=None, **kwargs) -> Tuple[Dict[str, np.ndarray], Dict[str, Any]]:
         mujoco.mj_resetData(self._model, self._data)
+
+        # Clear any prior capture so the screen returns to live preview.
+        self._captured_image = None
+        self._capture_flash_frame = 0
+        self._latest_shutter_pressed = False
 
         self.delta_h = np.float64(np.random.uniform(*_TABLE_HEIGHT_BOUNDS))
         table_pos = self._model.body("table").pos
@@ -794,6 +835,7 @@ class PandaBimanualPhotographGymEnv(MujocoGymEnv):
             mujoco.mj_step(self._model, self._data)
 
         success, metrics = self._compute_success_metrics()
+        self._latest_shutter_pressed = bool(metrics.get("shutter_pressed", False))
         obs = self._compute_observation(metrics=metrics)
         self.env_step += 1
 

--- a/dexjoco/dexjoco/sim/envs/panda_bimanual_photograph_env.py
+++ b/dexjoco/dexjoco/sim/envs/panda_bimanual_photograph_env.py
@@ -106,11 +106,13 @@ class PandaBimanualPhotographGymEnv(MujocoGymEnv):
         randomize_dynamics: bool = False,
         config=None,
         hz: int = 30,
+        camera_screen_effect: bool = True,
     ):
         self.hz = hz
         self._action_scale = action_scale
         self.randomize = randomize
         self._randomize_dynamics = randomize_dynamics
+        self._camera_screen_effect = bool(camera_screen_effect)
 
         super().__init__(
             xml_path=_XML_PATH,
@@ -243,6 +245,9 @@ class PandaBimanualPhotographGymEnv(MujocoGymEnv):
         self._screen_tex_adr = 0
         self._screen_tex_nchan = 3
         self._init_camera_screen_streaming()
+
+        if not self._camera_screen_effect:
+            self._hide_camera_screen_geom()
 
         # Photo capture / flash state.
         self._capture_flash_total = 5  # ~0.17 s of flash at hz=30
@@ -531,7 +536,7 @@ class PandaBimanualPhotographGymEnv(MujocoGymEnv):
 
     def _update_camera_screen_texture(self):
         """Drive the camera screen: live preview, capture flash, or frozen photo."""
-        if self._screen_tex_id < 0:
+        if self._screen_tex_id < 0 or not self._camera_screen_effect:
             return
 
         if self._captured_image is None:
@@ -603,6 +608,20 @@ class PandaBimanualPhotographGymEnv(MujocoGymEnv):
         adr = self._screen_tex_adr
         self._model.tex_data[adr:adr + flat.size] = flat
         self._upload_screen_texture_to_all_viewers()
+
+    def _hide_camera_screen_geom(self):
+        """Make the camera_live_screen geom visually disappear (used when the
+        camera-screen effect is disabled)."""
+        try:
+            gid = int(self._model.geom("camera_live_screen").id)
+        except Exception:
+            return
+        try:
+            self._model.geom_matid[gid] = -1
+            self._model.geom_rgba[gid] = np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+            self._model.geom_size[gid] = np.array([1e-9, 1e-9, 1e-9], dtype=np.float64)
+        except Exception:
+            pass
 
     def _upload_screen_texture_to_all_viewers(self):
         if self._screen_tex_id < 0:

--- a/scripts/record_demos_zarr.py
+++ b/scripts/record_demos_zarr.py
@@ -60,6 +60,13 @@ flags.DEFINE_bool(
     False,
     "Also render a depth_array per RGB camera and save <cam>_depth.npz + .mp4 alongside each video",
 )
+flags.DEFINE_bool(
+    "camera_screen_effect",
+    True,
+    "(bimanual_photograph only) Enable the camera live-screen effect "
+    "(live preview + shutter flash + frozen photo). When False, the screen "
+    "geom is hidden entirely.",
+)
 
 
 def _ensure_base_outdir(base: str) -> Path:
@@ -432,9 +439,14 @@ def main(_argv):
 
     config = CONFIG_MAPPING[task_id]()
 
+    env_extra_kwargs = {}
+    if task_id == "bimanual_photograph":
+        env_extra_kwargs["camera_screen_effect"] = FLAGS.camera_screen_effect
+
     env = config.get_environment(
         render_mode=FLAGS.render_mode,
         randomize=FLAGS.randomize,
+        **env_extra_kwargs,
     )
 
     obs, info = env.reset()

--- a/scripts/replay_demos_zarr.py
+++ b/scripts/replay_demos_zarr.py
@@ -90,6 +90,13 @@ flags.DEFINE_bool(
     False,
     "Also render a depth_array per RGB camera and save <cam>_depth.npz + .mp4 alongside each video",
 )
+flags.DEFINE_bool(
+    "camera_screen_effect",
+    True,
+    "(bimanual_photograph only) Enable the camera live-screen effect "
+    "(live preview + shutter flash + frozen photo). When False, the screen "
+    "geom is hidden entirely.",
+)
 
 
 def _safe_squeeze_image(img: np.ndarray) -> np.ndarray:
@@ -281,12 +288,17 @@ def _replay_single_demo(
     env_seed: int,
     desc: str,
 ):
+    env_extra_kwargs = {}
+    if task_id == "bimanual_photograph":
+        env_extra_kwargs["camera_screen_effect"] = FLAGS.camera_screen_effect
+
     env = config.get_environment(
         policy_mode=True,
         render_mode="rgb_array",
         randomize=FLAGS.randomize,
         randomize_dynamics=False,
         seed=env_seed,
+        **env_extra_kwargs,
     )
     try:
         obs, _info = env.reset()


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                           
  - On first shutter press, the photograph camera screen now caches the current `cam_pos_z` frame, blends a white sheet over it with a linear alpha fade (~0.17 s at 30 Hz), then freezes on the cached photo until the next `reset()`.
  - Expose a `camera_screen_effect: bool = True` kwarg on `PandaBimanualPhotographGymEnv`. When `False`, clear the screen geom's material, zero its rgba alpha, shrink its size, and short-circuit `_update_camera_screen_texture` so no `cam_pos_z` render runs each step.
  - Surface the toggle as `--camera_screen_effect` on `scripts/record_demos_zarr.py` and `scripts/replay_demos_zarr.py`, forwarded to the env only when the task is `bimanual_photograph`.

  ## Test plan
  - [ ] `python scripts/record_demos_zarr.py --exp_name bimanual_photograph` — confirm screen shows the live `cam_pos_z` view, flashes white when the shutter is pressed, then freezes on the captured photo, and that `reset()` returns to live preview.
  - [ ] `python scripts/record_demos_zarr.py --exp_name bimanual_photograph --camera_screen_effect=false` — confirm the screen geom is no longer visible on the camera body and no extra offscreen render fires per step.
  - [ ] `python scripts/replay_demos_zarr.py --exp_name bimanual_photograph --camera_screen_effect=false` — same toggle works in replay.                                                                                 
  - [ ] Sanity-check other tasks (e.g. `--exp_name water_plant`) still record/replay normally; the `--camera_screen_effect` flag should be a no-op there.